### PR TITLE
Add nginx-shopify formula

### DIFF
--- a/lua-nginx-internals-nginx-module.rb
+++ b/lua-nginx-internals-nginx-module.rb
@@ -1,0 +1,13 @@
+class LuaNginxInternalsNginxModule < Formula
+  desc "Nginx C module to expose Lua API to access nginx internals"
+  homepage "https://github.com/openresty/lua-upstream-nginx-module"
+  head "https://github.com/shopify/lua-nginx-internals-nginx-module.git"
+
+  bottle :unneeded
+
+  depends_on "lua-nginx-module"
+
+  def install
+    (share+"lua-nginx-internals-nginx-module").install Dir["*"]
+  end
+end

--- a/lua-nginx-module.rb
+++ b/lua-nginx-module.rb
@@ -1,0 +1,16 @@
+class LuaNginxModule < Formula
+  desc "Embed the power of Lua into Nginx"
+  homepage "https://github.com/openresty/lua-nginx-module"
+  url "https://github.com/openresty/lua-nginx-module/archive/v0.10.5.tar.gz"
+  sha256 "4f0292c37ab3d7cb980c994825040be1bda2c769cbd800e79c43eb37458347d4"
+  head "https://github.com/openresty/lua-nginx-module.git"
+
+  bottle :unneeded
+
+  depends_on "luajit-shopify"
+  depends_on "ngx-devel-kit"
+
+  def install
+    (share+"lua-nginx-module").install Dir["*"]
+  end
+end

--- a/lua-upstream-nginx-module.rb
+++ b/lua-upstream-nginx-module.rb
@@ -1,0 +1,20 @@
+class LuaUpstreamNginxModule < Formula
+  desc "Nginx C module to expose Lua API to ngx_lua for Nginx upstreams"
+  homepage "https://github.com/openresty/lua-upstream-nginx-module"
+  url "https://github.com/openresty/lua-upstream-nginx-module/archive/v0.05.tar.gz"
+  sha256 "0fdfb17083598e674680d8babe944f48a9ccd2af9f982eda030c446c93cfe72b"
+  head "https://github.com/openresty/lua-upstream-nginx-module.git"
+
+  bottle :unneeded
+
+  depends_on "lua-nginx-module"
+
+  patch do
+    url "https://gist.githubusercontent.com/csfrancis/4b6ca42b9903f4cef1e05580b2dba1d9/raw/4a64ab78362dfd876c9d4c61f2d11426a4d6de32/current_upstream_name.patch"
+    sha256 "8a36dcca3ed5c3795eb3b635addc1f267a29bd9dcf72a22c56009f6d7f775124"
+  end
+
+  def install
+    (share+"lua-upstream-nginx-module").install Dir["*"]
+  end
+end

--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -1,0 +1,65 @@
+class LuajitShopify < Formula
+  desc "Just-In-Time Compiler (JIT) for the Lua programming language"
+  homepage "http://luajit.org/luajit.html"
+  url "http://luajit.org/download/LuaJIT-2.1.0-beta2.tar.gz"
+  sha256 "713924ca034b9d99c84a0b7b701794c359ffb54f8e3aa2b84fad52d98384cf47"
+  head "http://luajit.org/git/luajit-2.0.git"
+
+  bottle do
+    root_url "https://s3.amazonaws.com/homebrew-bottles"
+    sha256 "d6999029f4d5a4e18c4f338aa8746aa1f2780da863611e802af377422d39d41d" => :el_capitan
+  end
+
+  conflicts_with "luajit", :because => "shopify uses luajit 2.1. `brew uninstall luajit` first"
+
+  # https://github.com/LuaJIT/LuaJIT/issues/180
+  patch do
+    url "https://github.com/LuaJIT/LuaJIT/commit/5837c2a2fb1ba6651.diff"
+    sha256 "7b5d233fc3a95437bd1c8459ad35bba63825655f47951b6dba1d053df7f98587"
+  end
+
+  deprecated_option "enable-debug" => "with-debug"
+
+  option "with-debug", "Build with debugging symbols"
+  option "with-52compat", "Build with additional Lua 5.2 compatibility"
+
+  def install
+    # 1 - Override the hardcoded gcc.
+    # 2 - Remove the "-march=i686" so we can set the march in cflags.
+    # Both changes should persist and were discussed upstream.
+    inreplace "src/Makefile" do |f|
+      f.change_make_var! "CC", ENV.cc
+      f.change_make_var! "CCOPT_x86", ""
+    end
+
+    ENV.O2 # Respect the developer's choice.
+
+    args = %W[PREFIX=#{prefix}]
+    args << "XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT" if build.with? "52compat"
+
+    # This doesn't yet work under superenv because it removes "-g"
+    args << "CCDEBUG=-g" if build.with? "debug"
+
+    # The development branch of LuaJIT normally does not install "luajit".
+    args << "INSTALL_TNAME=luajit"
+
+    system "make", "amalg", *args
+    system "make", "install", *args
+
+    # LuaJIT doesn't automatically symlink unversioned libraries:
+    # https://github.com/Homebrew/homebrew/issues/45854.
+    lib.install_symlink lib/"libluajit-5.1.dylib" => "libluajit.dylib"
+    lib.install_symlink lib/"libluajit-5.1.a" => "libluajit.a"
+
+    # Having an empty Lua dir in lib/share can mess with other Homebrew Luas.
+    %W[ #{lib}/lua #{share}/lua ].each { |d| rm_rf d }
+  end
+
+  test do
+    system "#{bin}/luajit", "-e", <<-EOS.undent
+      local ffi = require("ffi")
+      ffi.cdef("int printf(const char *fmt, ...);")
+      ffi.C.printf("Hello %s!\\n", "#{ENV["USER"]}")
+    EOS
+  end
+end

--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -1,0 +1,119 @@
+class NginxShopify < Formula
+  desc "HTTP(S) server, reverse proxy, IMAP/POP3 proxy server"
+  homepage "http://nginx.org/"
+  url "https://nginx.org/download/nginx-1.9.14.tar.gz"
+  sha256 "2b4893076d28e6b4384bba8c4fdebfca6de6f8f68ec48a1ca94b9b855ff457d2"
+  head "http://hg.nginx.org/nginx/", :using => :hg
+
+  bottle do
+    root_url "https://s3.amazonaws.com/homebrew-bottles"
+    sha256 "81f2ed640f64405fd6d2d11c6eeb526cd41d1025c0f714abcdea4eacb0958f48" => :el_capitan
+  end
+
+  conflicts_with "nginx", :because => "shopify has a custom nginx build. `brew uninstall nginx` first"
+
+  def self.nginx_modules
+    {
+      "ngx-devel-kit" => :build,
+      "lua-nginx-module" => :build,
+      "lua-upstream-nginx-module" => :build,
+      "lua-nginx-internals-nginx-module" => [:build, "HEAD"]
+    }
+  end
+
+  depends_on "pcre"
+  depends_on "geoip"
+  depends_on "openssl"
+  depends_on "luajit-shopify"
+  nginx_modules.each { |m, v| depends_on m => v }
+
+  patch do
+    url "https://gist.githubusercontent.com/csfrancis/4b6ca42b9903f4cef1e05580b2dba1d9/raw/4a64ab78362dfd876c9d4c61f2d11426a4d6de32/openresty-ssl_cert_db_yield.patch"
+    sha256 "73f29eb281e7da95f4db3b33e44d318e685fef7328e79c6c01a7393f88cef788"
+  end
+
+  env :userpaths
+  skip_clean "logs"
+
+  def install
+    pcre = Formula["pcre"]
+    openssl = Formula["openssl"]
+    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{pcre.include} -I#{openssl.include}"
+    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{pcre.lib} -L#{openssl.lib}"
+
+    args = %W[
+      --prefix=#{prefix}
+      --with-http_ssl_module
+      --with-http_realip_module
+      --with-http_stub_status_module
+      --with-http_geoip_module
+      --with-http_v2_module
+      --with-stream
+      --with-ipv6
+      --with-pcre
+      --sbin-path=#{bin}/nginx
+      --with-cc-opt=#{cc_opt}
+      --with-ld-opt=#{ld_opt}
+      --conf-path=#{etc}/nginx/nginx.conf
+      --pid-path=#{var}/run/nginx.pid
+      --lock-path=#{var}/run/nginx.lock
+      --http-client-body-temp-path=#{var}/run/nginx/client_body_temp
+      --http-proxy-temp-path=#{var}/run/nginx/proxy_temp
+      --http-fastcgi-temp-path=#{var}/run/nginx/fastcgi_temp
+      --http-uwsgi-temp-path=#{var}/run/nginx/uwsgi_temp
+      --http-scgi-temp-path=#{var}/run/nginx/scgi_temp
+      --http-log-path=#{var}/log/nginx/access.log
+      --error-log-path=#{var}/log/nginx/error.log
+    ]
+
+    self.class.nginx_modules.each_key do |m|
+      args << "--add-module=#{HOMEBREW_PREFIX}/share/#{m}"
+    end
+
+    luajit_path = `brew --prefix luajit-shopify`.chomp
+    ENV["LUAJIT_LIB"] = "#{luajit_path}/lib"
+    ENV["LUAJIT_INC"] = "#{luajit_path}/include/luajit-2.1"
+
+    if build.head?
+      system "./auto/configure", *args
+    else
+      system "./configure", *args
+    end
+
+    system "make", "install"
+    if build.head?
+      man8.install "docs/man/nginx.8"
+    else
+      man8.install "man/nginx.8"
+    end
+
+    (etc/"nginx/servers").mkpath
+    (var/"run/nginx").mkpath
+  end
+
+  def post_install
+    # nginx's docroot is #{prefix}/html, this isn't useful, so we symlink it
+    # to #{HOMEBREW_PREFIX}/var/www. The reason we symlink instead of patching
+    # is so the user can redirect it easily to something else if they choose.
+    html = prefix/"html"
+    dst = var/"www"
+
+    if dst.exist?
+      html.rmtree
+      dst.mkpath
+    else
+      dst.dirname.mkpath
+      html.rename(dst)
+    end
+
+    prefix.install_symlink dst => "html"
+
+    # for most of this formula's life the binary has been placed in sbin
+    # and Homebrew used to suggest the user copy the plist for nginx to their
+    # ~/Library/LaunchAgents directory. So we need to have a symlink there
+    # for such cases
+    if rack.subdirs.any? { |d| d.join("sbin").directory? }
+      sbin.install_symlink bin/"nginx"
+    end
+  end
+end

--- a/ngx-devel-kit.rb
+++ b/ngx-devel-kit.rb
@@ -1,0 +1,13 @@
+class NgxDevelKit < Formula
+  desc "Nginx Development Kit"
+  homepage "https://github.com/simpl/ngx_devel_kit"
+  url "https://github.com/simpl/ngx_devel_kit/archive/v0.3.0.tar.gz"
+  sha256 "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
+  head "https://github.com/simpl/ngx_devel_kit.git"
+
+  bottle :unneeded
+
+  def install
+    (share+"ngx-devel-kit").install Dir["*"]
+  end
+end


### PR DESCRIPTION
@burke 

Adds formula(s) requires to build an nginx build that is essentially the same as what's built by https://github.com/Shopify/nginx-shopify-build.

I made the nginx modules separate formulas, following the same pattern used by https://github.com/Homebrew/homebrew-nginx/tree/master/Formula. They probably could have been `resource`s within the `nginx-shopify` formula, but `lua-upstream-nginx-module` requires a patch, and I didn't want to have to deal with patching files in a resource.
