### PR TITLE
Fix nginx-shopify post-install

### DIFF
--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -97,6 +97,7 @@ class NginxShopify < Formula
       html.rmtree
       dst.mkpath
     else
+      dst.rmtree if dst.symlink? && !File.exist?(dst)
       dst.dirname.mkpath
       html.rename(dst)
     end


### PR DESCRIPTION
@Sirupsen, @es 

Fixes the error on `brew postinstall nginx-shopify`. This removes the `/usr/local/var/www` symlink if it's broken.
