### PR TITLE
Custom CS 1.0.1f build

### DIFF
--- a/cs-openssl.rb
+++ b/cs-openssl.rb
@@ -1,0 +1,156 @@
+class CsOpenssl < Formula
+  desc "SSL/TLS cryptography library"
+  homepage "https://openssl.org"
+  url "https://www.openssl.org/source/openssl-1.0.1f.tar.gz"
+  sha256 "6cc2a80b17d64de6b7bac985745fdaba971d54ffd7d38d3556f998d7c0c9cb5a"
+  revision 1
+
+  def pour_bottle?
+    false
+  end
+
+  keg_only :provided_by_osx,
+    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
+
+  option :universal
+  option "without-test", "Skip build-time tests (not recommended)"
+
+  deprecated_option "without-check" => "without-test"
+
+  depends_on "makedepend" => :build
+
+  # OpenSSL let the certs used for testing in the 1.0.1 branch expire
+  # and consequently `make test` now dies a horrible death.
+  # I'm not even joking.
+  # https://mta.openssl.org/pipermail/openssl-dev/2016-May/006983.html
+  patch do
+    url "https://github.com/openssl/openssl/commit/24762dee178bace.diff"
+    sha256 "7cfdb6248054602688c26a8f448c4489881684fe44dfef6727fb5dc0845dfd8b"
+  end
+
+  def arch_args
+    {
+      :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
+      :i386   => %w[darwin-i386-cc],
+    }
+  end
+
+  def configure_args; %W[
+    --prefix=#{prefix}
+    --openssldir=#{openssldir}
+    no-ssl2
+    no-ssl3
+    zlib-dynamic
+    shared
+    enable-cms
+  ]
+  end
+
+  def install
+    if build.universal?
+      ENV.permit_arch_flags
+      archs = Hardware::CPU.universal_archs
+    elsif MacOS.prefer_64_bit?
+      archs = [Hardware::CPU.arch_64_bit]
+    else
+      archs = [Hardware::CPU.arch_32_bit]
+    end
+
+    dirs = []
+
+    archs.each do |arch|
+      if build.universal?
+        dir = "build-#{arch}"
+        dirs << dir
+        mkdir dir
+        mkdir "#{dir}/engines"
+        system "make", "clean"
+      end
+
+      ENV.deparallelize
+      system "perl", "./Configure", *(configure_args + arch_args[arch])
+      system "make", "depend"
+      system "make"
+
+      if (MacOS.prefer_64_bit? || arch == MacOS.preferred_arch) && build.with?("test")
+        system "make", "test"
+      end
+
+      if build.universal?
+        cp Dir["*.?.?.?.dylib", "*.a", "apps/openssl"], dir
+        cp Dir["engines/**/*.dylib"], "#{dir}/engines"
+      end
+    end
+
+    system "make", "install_sw"
+
+    if build.universal?
+      %w[libcrypto libssl].each do |libname|
+        system "lipo", "-create", "#{dirs.first}/#{libname}.1.0.0.dylib",
+                                  "#{dirs.last}/#{libname}.1.0.0.dylib",
+                       "-output", "#{lib}/#{libname}.1.0.0.dylib"
+        system "lipo", "-create", "#{dirs.first}/#{libname}.a",
+                                  "#{dirs.last}/#{libname}.a",
+                       "-output", "#{lib}/#{libname}.a"
+      end
+
+      Dir.glob("#{dirs.first}/engines/*.dylib") do |engine|
+        libname = File.basename(engine)
+        system "lipo", "-create", "#{dirs.first}/engines/#{libname}",
+                                  "#{dirs.last}/engines/#{libname}",
+                       "-output", "#{lib}/engines/#{libname}"
+      end
+
+      system "lipo", "-create", "#{dirs.first}/openssl",
+                                "#{dirs.last}/openssl",
+                     "-output", "#{bin}/openssl"
+    end
+  end
+
+  def openssldir
+    etc/"openssl"
+  end
+
+  def post_install
+    keychains = %w[
+      /System/Library/Keychains/SystemRootCertificates.keychain
+    ]
+
+    certs_list = `security find-certificate -a -p #{keychains.join(" ")}`
+    certs = certs_list.scan(
+      /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
+    )
+
+    valid_certs = certs.select do |cert|
+      IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
+        openssl_io.write(cert)
+        openssl_io.close_write
+      end
+
+      $?.success?
+    end
+
+    openssldir.mkpath
+    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+  end
+
+  def caveats; <<-EOS.undent
+    A CA file has been bootstrapped using certificates from the system
+    keychain. To add additional certificates, place .pem files in
+      #{openssldir}/certs
+
+    and run
+      #{opt_bin}/c_rehash
+    EOS
+  end
+
+  test do
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system "#{bin}/openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end


### PR DESCRIPTION
Build process:

```
==> Downloading https://www.openssl.org/source/openssl-1.0.1f.tar.gz
Already downloaded: /Users/lourens/Library/Caches/Homebrew/cs-openssl-1.0.1f.tar.gz
==> Downloading https://github.com/openssl/openssl/commit/24762dee178bace.diff
Already downloaded: /Users/lourens/Library/Caches/Homebrew/cs-openssl--patch-7cfdb6248054602688c26a8f448c4489881684fe44dfef6727fb5dc0845dfd8b.diff
==> Patching
==> Applying 24762dee178bace.diff
patching file test/smime-certs/smdsa1.pem
patching file test/smime-certs/smdsa2.pem
patching file test/smime-certs/smdsa3.pem
patching file test/smime-certs/smroot.pem
patching file test/smime-certs/smrsa1.pem
patching file test/smime-certs/smrsa2.pem
patching file test/smime-certs/smrsa3.pem
==> perl ./Configure --prefix=/usr/local/Cellar/cs-openssl/1.0.1f_1 --openssldir=/usr/local/etc/openssl no-ssl2 no-ssl3 zlib-dynamic shared enable-cms darwin64-x86_64-cc enable-ec_nistp_64_gcc_128
==> make depend
==> make
==> make test
==> make install_sw
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /usr/local/etc/openssl/certs

and run
  /usr/local/opt/cs-openssl/bin/c_rehash

This formula is keg-only, which means it was not symlinked into /usr/local.

Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries

Generally there are no consequences of this for you. If you build your
own software and it requires this formula, you'll need to add to your
build variables:

    LDFLAGS:  -L/usr/local/opt/cs-openssl/lib
    CPPFLAGS: -I/usr/local/opt/cs-openssl/include

==> Summary
🍺  /usr/local/Cellar/cs-openssl/1.0.1f_1: 103 files, 7.7M, built in 3 minutes 35 seconds
```

@pallan @baldowl @kvs 