### PR TITLE
Use HTTPS root URLs when pouring bottles

### DIFF
--- a/ejson.rb
+++ b/ejson.rb
@@ -5,7 +5,7 @@ class Ejson < Formula
   sha256 'a0d351b53e8bf3368276fced733f94054aca88b4ef5ef0a3a5000dfb23f5435f'
 
   bottle do
-    root_url "http://burkelibbey.s3.amazonaws.com"
+    root_url "https://s3.amazonaws.com/burkelibbey"
     cellar :any_skip_relocation
     sha256 "3e47d357ebf78a91c83eb2f5c44a7d769b7558a310fcc99a17fa7258ef6f3d2d" => :sierra
     sha256 "4eb87a4dedc180cec1341280380febf81eaa6261a6811ea54d653d18eae0bc6f" => :el_capitan

--- a/libzookeeper.rb
+++ b/libzookeeper.rb
@@ -8,7 +8,7 @@ class Libzookeeper < Formula
   end
 
   bottle do
-    root_url "http://burkelibbey.s3.amazonaws.com"
+    root_url "https://s3.amazonaws.com/burkelibbey"
     cellar :any
     rebuild 1
     sha256 "c9b20ecb4b96ba7cd9a4f21557df302bfc7bacb2e6439e8a73f1d8df05ab26cb" => :sierra

--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -5,7 +5,7 @@ class MysqlClient < Formula
   sha256 "1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74"
 
   bottle do
-    root_url "http://burkelibbey.s3.amazonaws.com"
+    root_url "https://s3.amazonaws.com/burkelibbey"
     rebuild 1
     sha256 "6c1ca55896635994d1fac5cbc2703062443515d4eaa676d1251ab7a9a40d943a" => :sierra
   end

--- a/shopify-graphicsmagick.rb
+++ b/shopify-graphicsmagick.rb
@@ -10,7 +10,7 @@ class ShopifyGraphicsmagick < Formula
   revision 2
 
   bottle do
-    root_url "http://burkelibbey.s3.amazonaws.com"
+    root_url "https://s3.amazonaws.com/burkelibbey"
     sha256 "625cb0e794c282e0724240e4627b63bb92d3ef32ecfdc783ad35e3f323d94278" => :sierra
   end
 

--- a/shopify-ruby.rb
+++ b/shopify-ruby.rb
@@ -16,7 +16,7 @@ class ShopifyRuby < Formula
   end
 
   bottle do
-    root_url "http://burkelibbey.s3.amazonaws.com"
+    root_url "https://s3.amazonaws.com/burkelibbey"
     rebuild 2
     sha256 "78dbba5c1744c944cef438678c1d1371536fc10654735b630d8621863501806c" => :sierra
   end


### PR DESCRIPTION
Switches to using path based bucket access instead of domain so we can piggyback
on Amazon's TLS certificate, and eliminate a MitM attack vector.
