### PR TITLE
Use $@ in quotes for literal args

### DIFF
--- a/presto-cli.rb
+++ b/presto-cli.rb
@@ -16,7 +16,7 @@ class PrestoCli < Formula
   def wrapper_script; <<-EOS.undent
     #!/bin/bash
 
-    java -Duser.timezone=UTC -jar #{lib}/presto-cli-#{version}-executable.jar --user $(whoami) --server ods1.hu131.data-chi.shopify.com:8082 $@
+    java -Duser.timezone=UTC -jar #{lib}/presto-cli-#{version}-executable.jar --user $(whoami) --server ods1.hu131.data-chi.shopify.com:8082 "$@"
     EOS
   end
 end


### PR DESCRIPTION
@JackMc @jduff /cc @Shopify/data-infrastructure 

In order to use `--execute "select * from foo"` (i.e. something with a `*`), you must wrap the `$@` in quotes so that the extra args are interpreted literally. Otherwise, the `*` is interpreted as a glob and you get an error like:

```
⌘ ~/code/shopify/shopify (master) presto --execute "select * from foo"
Exception in thread "main" io.airlift.airline.ParseArgumentsUnexpectedException:
Found unexpected parameters: [CONTRIBUTING.md, Capfile, ...
```