### PR TITLE
Fix broken client download URL

### DIFF
--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -1,8 +1,8 @@
 class MysqlClient < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.10.tar.gz"
-  sha256 "1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.14.tar.gz"
+  sha256 "f7415bdac2ca8bbccd77d4f22d8a0bdd7280b065bd646a71a506b77c7a8bd169"
 
   bottle do
     root_url "http://burkelibbey.s3.amazonaws.com"


### PR DESCRIPTION
This PR fixes `mysql-client` on macOS Sierra. `5.7.10` has been yanked, but you won't notice this on El Capitan because it will use bottle one.