### PR TITLE
Change SHA sum for rds-ssl to the new cert that's on S3

### DIFF
--- a/rds-ssl.rb
+++ b/rds-ssl.rb
@@ -2,7 +2,7 @@ class RdsSsl < Formula
   desc "Root public key for Amazon redshift SSL connectivity"
   homepage "http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Connect.html"
   url "http://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
-  sha256 "58c92aea3a96591abdd0c6ebb4116d9e33af946196bc1e43196961b1b0eac415"
+  sha256 "90567481d386dac26f4c734d83bbe8576955b2a6c84b00fc5113cdf1b7d87ea0"
   version "0.2.0"
 
   def install


### PR DESCRIPTION
This happened *again*, this is a quick fix but we should figure out what changes this cert (is it Amazon rotating it? Do we do something to trigger it?)

Previous incidence of this was #14