### PR TITLE
Update nginx-shopify.rb

### DIFF
--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -12,7 +12,7 @@ class NginxShopify < Formula
       "ngx-devel-kit" => :build,
       "lua-nginx-module" => :build,
       "lua-upstream-nginx-module" => :build,
-      "lua-nginx-internals-nginx-module" => [:build, "HEAD"]
+      "lua-nginx-internals-nginx-module" => :build
     }
   end
 


### PR DESCRIPTION
It seems like `brew` now appends a shorthash to the directory it installs `HEAD` into which breaks dependencies on `HEAD` as a version. Tracking `HEAD` dependencies is unsupported in homebrew and has been working by abusing undefined behaviours.

I'm switching this dependency to just track versions normally (which should cause it to track `master`). 
@csfrancis @es @burke 