### PR TITLE
updated the expected sha

### DIFF
--- a/rds-ssl.rb
+++ b/rds-ssl.rb
@@ -2,7 +2,7 @@ class RdsSsl < Formula
   desc "Root public key for Amazon redshift SSL connectivity"
   homepage "http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Connect.html"
   url "http://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
-  sha256 "90567481d386dac26f4c734d83bbe8576955b2a6c84b00fc5113cdf1b7d87ea0"
+  sha256 "d8ef0551c3d97d91cc58dc73cd24f2f1d09d992276009d747252fc1dc2c5edef"
   version "0.2.0"
 
   def install


### PR DESCRIPTION
to account for

```
Sams-MacBook-Pro-2% brew install rds-ssl
==> Installing rds-ssl from shopify/shopify
==> Downloading http://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 90567481d386dac26f4c734d83bbe8576955b2a6c84b00fc5113cdf1b7d87ea0
Actual: d8ef0551c3d97d91cc58dc73cd24f2f1d09d992276009d747252fc1dc2c5edef
Archive: /Users/samtalasila/Library/Caches/Homebrew/rds-ssl-0.2.0.pem
To retry an incomplete download, remove the file above.
```

@JackMc 