### PR TITLE
Add bottles for Sierra, removing ElCap bottles in most cases.

### DIFF
--- a/libzookeeper.rb
+++ b/libzookeeper.rb
@@ -10,7 +10,8 @@ class Libzookeeper < Formula
   bottle do
     root_url "http://burkelibbey.s3.amazonaws.com"
     cellar :any
-    sha256 "20f915a20fb978941bb52af74b50c4cea5b09ce21caee078cb83a8a7671b073e" => :el_capitan
+    rebuild 1
+    sha256 "c9b20ecb4b96ba7cd9a4f21557df302bfc7bacb2e6439e8a73f1d8df05ab26cb" => :sierra
   end
 
   def install

--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -6,8 +6,9 @@ class LuajitShopify < Formula
   head "http://luajit.org/git/luajit-2.0.git"
 
   bottle do
-    root_url "https://s3.amazonaws.com/homebrew-bottles"
-    sha256 "d6999029f4d5a4e18c4f338aa8746aa1f2780da863611e802af377422d39d41d" => :el_capitan
+    root_url "http://burkelibbey.s3.amazonaws.com"
+    rebuild 1
+    sha256 "614270751ee3379f1aa931accefc6d29d0b97b3bdf19e1ef550bb8b32e0d7954" => :sierra
   end
 
   conflicts_with "luajit", :because => "shopify uses luajit 2.1. `brew uninstall luajit` first"

--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -6,7 +6,8 @@ class MysqlClient < Formula
 
   bottle do
     root_url "http://burkelibbey.s3.amazonaws.com"
-    sha256 "922c3e8d858eef75bc9ee0db7dd455d588a17d5afc9282e77e7fad33a2191a4f" => :el_capitan
+    rebuild 1
+    sha256 "6c1ca55896635994d1fac5cbc2703062443515d4eaa676d1251ab7a9a40d943a" => :sierra
   end
 
   depends_on "cmake" => :build

--- a/shopify-libgraphqlparser.rb
+++ b/shopify-libgraphqlparser.rb
@@ -13,6 +13,13 @@ class ShopifyLibgraphqlparser < Formula
     sha256 "1dfc83c494e8ceef8eb5d757190312d13ecafeb1b88464c44073417989bf5488" => :mavericks
   end
 
+  bottle do
+    root_url "http://burkelibbey.s3.amazonaws.com"
+    cellar :any
+    rebuild 1
+    sha256 "6b9f8ed85728208f184cd5a2fd218a768d6e7052200d21f3504593e05b1fc3ca" => :sierra
+  end
+
   conflicts_with "libgraphqlparser", :because => "shopify-libgraphqlparser is different"
 
   depends_on "cmake" => :build

--- a/shopify-ruby.rb
+++ b/shopify-ruby.rb
@@ -14,11 +14,11 @@ class ShopifyRuby < Formula
   def abi_version
     "2.2.3"
   end
-  
+
   bottle do
     root_url "http://burkelibbey.s3.amazonaws.com"
-    revision 1
-    sha256 "7b63ba6fb49c81c2175294ceb5aa0140f63bed63365eeee5c57fbfeb8a27c3b5" => :el_capitan
+    rebuild 2
+    sha256 "78dbba5c1744c944cef438678c1d1371536fc10654735b630d8621863501806c" => :sierra
   end
 
   keg_only "because chruby"


### PR DESCRIPTION
@Shopify/dev-infra FYI. The process to build these is:

```bash
brew install --build-bottle libzookeeper
brew bottle libzookeeper
s3cmd put libzookeeper*tar.gz s3://whatever/<same filename>
```

I'm using my own s3 bucket here because it's write-once and checksum-verified so it doesn't really matter. You can use whatever bucket and just change the root_url if you ever need to push one.

@boourns because that old libgraphqlparser version is still in here. I added a sierra bottle to it ¯\\\_(ツ)\_/¯ 