### PR TITLE
Upload shopify-terraform version 0.7.7 to Homebrew

### DIFF
--- a/shopify-terraform.rb
+++ b/shopify-terraform.rb
@@ -1,9 +1,9 @@
 class ShopifyTerraform < Formula
   desc "Shopify fork of Terraform"
   homepage "https://github.com/Shopify/shopify-terraform"
-  url "https://s3.amazonaws.com/shopify-terraform-binaries/darwin_amd64_2265c81e16f3d44b0be158bd4cd29a6eaf0a8caf.tar.gz"
-  sha256 "7fe5945df5d75ce25c2c8a67a1064389218d59993addb95f2e0ec26d0a778b01"
-  version "0.6.7-shopify"
+  url "https://s3.amazonaws.com/shopify-terraform-binaries/darwin_amd64_d9349fd80c39c9435ab5212279cc4befce589019.tar.gz"
+  sha256 "f5bbb7dabe0c400e60b62cc3cc46de886e3996cfb14ffde2365a623b9548ab77"
+  version "0.7.7-shopify"
 
   conflicts_with "terraform", :because => "both install terraform binaries"
 


### PR DESCRIPTION
This PR uploads shopify-terraform v0.7.7 to Homebrew. 

r/ @thegedge @sbfaulkner @RyanBrushett 