### PR TITLE
Add libfaketime formula

### DIFF
--- a/shopify-libfaketime.rb
+++ b/shopify-libfaketime.rb
@@ -1,0 +1,20 @@
+# Documentation: https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md
+#                http://www.rubydoc.info/github/Homebrew/brew/master/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+
+class ShopifyLibfaketime < Formula
+  desc "Report faked system time to programs"
+  homepage "https://github.com/wolfcw/libfaketime/"
+  url "https://github.com/wolfcw/libfaketime/archive/macos-sierra.zip"
+  version "sierra"
+  sha256 "a1123197e4c6ccf446131f5347e5505eb1cfc85451533c1247a9c444a77d53b6"
+
+  depends_on :macos => :sierra
+
+  def install
+    system "make", "-C", "src", "-f", "Makefile.OSX", "PREFIX=#{prefix}"
+    bin.install "src/faketime"
+    (lib/"faketime").install "src/libfaketime.1.dylib"
+    man1.install "man/faketime.1"
+  end
+end


### PR DESCRIPTION
Because of the missing release version for sierra the official homebrew formula is not supporting sierra. This formula installs `libfaketime` from the working github branch.

After installing faketime you can start any process with 
```
$ faketime '2018-05-12' time.rb
=> 2018-05-12 00:00:03 -0400
```

A few concerns/questions:

- `libfaketime` does not work for System Integrity Protection (SIP) binaries on OSX. Which means anything shipping with osx does not work (e.g. `/bin/date`) https://github.com/wolfcw/libfaketime/issues/99#issuecomment-257151520
- This formula ONLY works for sierra right now. Is there a way for osx version checking and splitting install formulas in Homebrew?

@Shopify/dev-acceleration
