### PR TITLE
This Makefile is unconventional and only `make install` should be used.

### DIFF
--- a/docker-ssh-agent-forward.rb
+++ b/docker-ssh-agent-forward.rb
@@ -7,7 +7,6 @@ class DockerSshAgentForward < Formula
     ENV['PATH']   = "#{ENV['PATH']}:/usr/local/bin"
     ENV['PREFIX'] = prefix
 
-    system "make"
     system "make", "install"
   end
 end


### PR DESCRIPTION
@burke PTAL. This recipe was failing while trying to `dev up` Locutus. The reason is that the `Makefile` for 
`docker-ssh-agent-forward` is unconventional. `make all` doesn't do anything Make-ish and also depends on `make install` having run.

🎩 :

```
Eriks-MacBook-Pro:src erikwright$ rm -rf /usr/local/bin/pinata-*
Eriks-MacBook-Pro:src erikwright$ brew uninstall docker-ssh-agent-forward
Uninstalling /usr/local/Cellar/docker-ssh-agent-forward/HEAD-86ec6df... (10 files, 5.4K)
Eriks-MacBook-Pro:src erikwright$ brew install --HEAD https://raw.githubusercontent.com/Shopify/homebrew-shopify/4252c7ea4e1776f507f14a2aab59a02b23220609/docker-ssh-agent-forward.rb
######################################################################## 100.0%
==> Cloning https://github.com/avsm/docker-ssh-agent-forward.git
Updating /Users/erikwright/Library/Caches/Homebrew/docker-ssh-agent-forward--git
==> Checking out branch master
==> make install
🍺  /usr/local/Cellar/docker-ssh-agent-forward/HEAD-86ec6df: 10 files, 5.4K, built in 1 second
Eriks-MacBook-Pro:src erikwright$ 
```