### PR TITLE
This adds the echo module to nginx

### DIFF
--- a/echo-nginx-module.rb
+++ b/echo-nginx-module.rb
@@ -1,0 +1,14 @@
+class EchoNginxModule < Formula
+  desc "ngx_echo - Brings echo, sleep, time, exec and more shell-style goodies to Nginx config file."
+  homepage "https://github.com/openresty/echo-nginx-module"
+  url "https://github.com/openresty/echo-nginx-module/archive/v0.60.tar.gz"
+  version "v0.60"
+  sha256 "1077da2229ac7d0a0215e9e6817e297c10697e095010d88f1adbd1add1ce9f4e"
+  bottle :unneeded
+
+  depends_on "lua-nginx-module"
+
+  def install
+    (share+"echo-nginx-module").install Dir["*"]
+  end
+end

--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -12,7 +12,8 @@ class NginxShopify < Formula
       "ngx-devel-kit" => :build,
       "lua-nginx-module" => :build,
       "lua-upstream-nginx-module" => :build,
-      "lua-nginx-internals-nginx-module" => :build
+      "lua-nginx-internals-nginx-module" => :build,
+      "echo-nginx-module" => :build
     }
   end
 


### PR DESCRIPTION
This adds the https://github.com/openresty/echo-nginx-module to nginx. The echo nginx module is needed to run the tests for https://github.com/Shopify/lua-resty-upstream-healthcheck where we need to implement ssl for healthchecks so that can move to the ☁️ 

@ElvinEfendi @csfrancis 

I 🎩  this on my machine by symlinking `homebrew-shopify -> /Users/leex/projects/shopify/homebrew-shopify` in `/usr/local/Homebrew/Library/Taps/shopify` so that it picks up the changes from here and then I `brew (un)install`ed nginx and it had the echo module.