### PR TITLE
Updating to critical themekit version

### DIFF
--- a/themekit.rb
+++ b/themekit.rb
@@ -1,9 +1,9 @@
 class Themekit < Formula
   desc 'Theme Kit is a tool kit for manipulating shopify themes'
   homepage 'https://shopify.github.io/themekit/'
-  url 'https://shopify-themekit.s3.amazonaws.com/v0.6.1/darwin-amd64/theme'
-  sha256 'a3ddaec8b8bc7b0dee76e905041fd28d3b9c7ea4fd0a43299cd3155f3dd51197'
-  version 'v0.6.1'
+  url 'https://shopify-themekit.s3.amazonaws.com/v0.6.4/darwin-amd64/theme'
+  sha256 '00781aaf68767e1cfebec819dd282c710950d31a47fcfb651ef557568cbe6a48'
+  version 'v0.6.4'
 
   def install
     bin.install 'theme'


### PR DESCRIPTION
Themekit had to change an API endpoint usage that will become deprecated soon so it is necessary to have homebrew up to date with the current version.

API issue reference: https://github.com/Shopify/shopify/issues/98379