### PR TITLE
WIP mods to the heka formula

### DIFF
--- a/heka.rb
+++ b/heka.rb
@@ -5,29 +5,13 @@ class Heka < Formula
 
   head "https://github.com/mozilla-services/heka.git"
 
-  depends_on "homebrew/versions/go14" => :build # heka needs 1.4 to build
-  depends_on "go" => :build # heka's 'mockgen' is hardcoded for 'go' - https://github.com/rafrombrc/gomock/blob/master/mockgen/reflect.go#L75
+  depends_on "go@1.4" => :build # heka needs 1.4 to build
+  depends_on "lua"   => :build
   depends_on "cmake30" => :build
 
   def install
-    system "bash -c 'source build.sh && make install'"
+    system "bash -c 'source build.sh  && make install'"
     cp_r (buildpath/"build/heka").children, prefix
   end
-
-  patch :DATA
 end
 
-__END__
-diff --git a/cmake/FindGo.cmake b/cmake/FindGo.cmake
-index b4f79f4..8667bf4 100644
---- a/cmake/FindGo.cmake
-+++ b/cmake/FindGo.cmake
-@@ -12,7 +12,7 @@
- #   find_package(Go 1.2 REQUIRED)
-
-
--find_program(GO_EXECUTABLE go PATHS ENV GOROOT GOPATH GOBIN PATH_SUFFIXES bin)
-+find_program(GO_EXECUTABLE go14 PATHS ENV GOROOT GOPATH GOBIN PATH_SUFFIXES bin)
- if (GO_EXECUTABLE)
-     execute_process(COMMAND ${GO_EXECUTABLE} version OUTPUT_VARIABLE GO_VERSION_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
-     if(GO_VERSION_OUTPUT MATCHES "go([0-9]+\\.[0-9]+\\.?[0-9]*)[a-zA-Z0-9]* ([^/]+)/(.*)")


### PR DESCRIPTION
```
Lourenss-MacBook-Air:homebrew-shopify lourens$ brew install heka.rb
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (shopify/shopify).
==> New Formulae
shopify/shopify/cmake30 ✔

==> Installing dependencies for heka: go@1.4
==> Installing heka dependency: go@1.4
==> Downloading https://homebrew.bintray.com/bottles/go@1.4-1.4.3.sierra.bottle.tar.gz
Already downloaded: /Users/lourens/Library/Caches/Homebrew/go@1.4-1.4.3.sierra.bottle.tar.gz
==> Pouring go@1.4-1.4.3.sierra.bottle.tar.gz
==> Caveats
As of go 1.2, a valid GOPATH is required to use the `go get` command:
  https://golang.org/doc/code.html#GOPATH

You may wish to add the GOROOT-based install location to your PATH:
  export PATH=$PATH:/usr/local/opt/go@1.4/libexec/bin

This formula is keg-only, which means it was not symlinked into /usr/local.

This is an alternate version of another formula.

If you need to have this software first in your PATH run:
  echo 'export PATH="/usr/local/opt/go@1.4/bin:$PATH"' >> ~/.bash_profile

==> Summary
🍺  /usr/local/Cellar/go@1.4/1.4.3: 4,551 files, 142.7MB
==> Installing heka 
==> Cloning https://github.com/mozilla-services/heka.git
Updating /Users/lourens/Library/Caches/Homebrew/heka--git
==> Checking out tag v0.10.0
==> bash -c 'source build.sh  && make install'
🍺  /usr/local/Cellar/heka/0.10.0: 2,396 files, 134.3MB, built in 2 minutes 55 seconds
```