### PR TITLE
Fix toxiproxy manual launch command name

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -23,7 +23,7 @@ class Toxiproxy < Formula
     end
   end
 
-  plist_options :manual => "toxiproxy"
+  plist_options :manual => "toxiproxy-proxy"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Currently, it prints out:

```
Or, if you don't want/need a background service you can just run:
  toxiproxy
```

Which is 😕 