### PR TITLE
Bump toxiproxy version

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -11,7 +11,7 @@ class Toxiproxy < Formula
   resource "cli" do
     url "https://github.com/Shopify/toxiproxy/releases/download/v2.1.1/toxiproxy-cli-darwin-amd64"
     sha256 "d34e2fd989a8d90b9c72cb7f52f354e4aa5fba5044eea98ad4ff83ca3a3aef2a"
-    version "2.1.1"
+    version "2.1.2"
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
This PR bumps the version of ToxiProxy to 2.1.2.