### PR TITLE
Fix toxiproxy SHA

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -5,7 +5,7 @@
 class Toxiproxy < Formula
   homepage "https://github.com/Shopify/toxiproxy"
   url "https://github.com/Shopify/toxiproxy/releases/download/v2.1.2/toxiproxy-server-darwin-amd64"
-  sha256 "9586e6f75edab06101fcea595e82178af95d50932974519061b66f67379dfd60"
+  sha256 "320581f9a190592bdcefffb158c7ec971d9fbe193e7718be3d8c75aa2204ef7f"
   version "2.1.2"
 
   resource "cli" do


### PR DESCRIPTION
Fixes the SHA for the current release of toxiproxy. Addresses https://github.com/Shopify/homebrew-shopify/issues/55.