### PR TITLE
Update Slate to 0.11.0

### DIFF
--- a/slate.rb
+++ b/slate.rb
@@ -3,16 +3,13 @@ require "language/node"
 class Slate < Formula
   desc "Command line tool for Shopify Theme development"
   homepage "https://shopify.github.io/slate/"
-  url "https://registry.npmjs.org/@shopify/slate/-/slate-0.10.0.tgz"
+  url "https://registry.npmjs.org/@shopify/slate/-/slate-0.11.0.tgz"
   sha256 "6b54d1930a3f1c72b343a07fd2800e33bc59be6e11c4773785292f33beeb2df0"
   head "https://github.com/Shopify/slate-cli.git"
 
   depends_on "node"
 
   def install
-    # remove me once https://github.com/Homebrew/brew/pull/2826 is released
-    inreplace "package.json", '"prepublish"', '"dont_run_me"'
-
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end


### PR DESCRIPTION
This PR is a fix in response to https://github.com/Shopify/homebrew-shopify/pull/52#issuecomment-311483637 - which removes the `inreplace` command as a temporary fix. Also updates Slate to the latest version.

cc @NathanPJF 