### PR TITLE
Upgrade to yarn@0.27.5

### DIFF
--- a/yarn.rb
+++ b/yarn.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Yarn < Formula
   desc "JavaScript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://yarnpkg.com/downloads/0.21.3/yarn-v0.21.3.tar.gz"
-  sha256 "0946a4d1abc106c131b700cc31e5c3aa5f2205eb3bb9d17411f8115354a97d5d"
+  url "https://yarnpkg.com/downloads/0.27.5/yarn-v0.27.5.tar.gz"
+  sha256 "f0f3510246ee74eb660ea06930dcded7b684eac2593aa979a7add84b72517968"
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do

--- a/yarn.rb
+++ b/yarn.rb
@@ -8,10 +8,9 @@ class Yarn < Formula
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do
+    root_url "https://burkelibbey.s3.amazonaws.com"
     cellar :any_skip_relocation
-    sha256 "20ebc2f2bce300095a0af7b9ef2aca712992bb24a8410424610ed133c3eabdef" => :sierra
-    sha256 "80a321ef5d474ce6d4093b994f425f43e4de05cf93b366c29190fe618fc4711b" => :el_capitan
-    sha256 "086f619f9712c9e012e9c1797db630b2118e2d91ad3ebc8102038d3da427353a" => :yosemite
+    sha256 "b43c66a5cc378712dc9871bcc31abb78ad1f9790a9b1226109bc1c2f98d1e626" => :sierra
   end
 
   depends_on "node"


### PR DESCRIPTION
Asset integrity problems are affecting many devs.  Upgrading to 0.27.5 has fixed it for at least one dev.