### PR TITLE
Bump echo-nginx-module to version 0.61.

### DIFF
--- a/echo-nginx-module.rb
+++ b/echo-nginx-module.rb
@@ -1,9 +1,9 @@
 class EchoNginxModule < Formula
   desc "ngx_echo - Brings echo, sleep, time, exec and more shell-style goodies to Nginx config file."
   homepage "https://github.com/openresty/echo-nginx-module"
-  url "https://github.com/openresty/echo-nginx-module/archive/v0.60.tar.gz"
-  version "v0.60"
-  sha256 "1077da2229ac7d0a0215e9e6817e297c10697e095010d88f1adbd1add1ce9f4e"
+  url "https://github.com/openresty/echo-nginx-module/archive/v0.61.tar.gz"
+  version "v0.61"
+  sha256 "2e6a03032555f5da1bdff2ae96c96486f447da3da37c117e0f964ae0753d22aa"
   bottle :unneeded
 
   depends_on "lua-nginx-module"


### PR DESCRIPTION
@Shopify/edgescale, @Shopify/routing 

This should have shipped with #64. I'm just going to merge since `brew install nginx-shopify` is currently broken with the following error:

```
marc:nginx-routing-modules marcbarry$ brew install nginx-shopify
==> Installing nginx-shopify from shopify/shopify
==> Downloading https://nginx.org/download/nginx-1.13.4.tar.gz
Already downloaded: /Users/marcbarry/Library/Caches/Homebrew/nginx-shopify-1.13.4.tar.gz
==> ./configure --prefix=/usr/local/Cellar/nginx-shopify/1.13.4 --with-http_ssl_module --with-http_realip_module --with-http_stub_status_module --with-http_geoip_module --with-htt
==> make install
Last 15 lines from /Users/marcbarry/Library/Logs/Homebrew/nginx-shopify/02.make:
		-o objs/addon/src/ngx_http_echo_foreach.o \
		/usr/local/share/echo-nginx-module/src/ngx_http_echo_foreach.c
clang -c -I/usr/local/opt/luajit-shopify/include/luajit-2.1  -pipe  -O -Wall -Wextra -Wpointer-arith -Wconditional-uninitialized -Wno-unused-parameter -Wno-deprecated-declarations -Werror -g -I/usr/local/include -I/usr/local/opt/pcre/include -I/usr/local/opt/openssl/include -DNDK_SET_VAR -I src/core -I src/event -I src/event/modules -I src/os/unix -I /usr/local/share/ngx-devel-kit/objs -I objs/addon/ndk -I /usr/local/share/lua-nginx-module/src/api -I /usr/local/share/lua-nginx-module/src -I objs \
		-o objs/ngx_modules.o \
		objs/ngx_modules.c
/usr/local/share/echo-nginx-module/src/ngx_http_echo_request_info.c:219:15: error: assigning to 'ngx_buf_t *' (aka 'struct ngx_buf_s *') from incompatible type 'ngx_chain_t' (aka 'struct ngx_chain_s')
            b = hc->busy[i];
              ^ ~~~~~~~~~~~
/usr/local/share/echo-nginx-module/src/ngx_http_echo_request_info.c:284:15: error: assigning to 'ngx_buf_t *' (aka 'struct ngx_buf_s *') from incompatible type 'ngx_chain_t' (aka 'struct ngx_chain_s')
            b = hc->busy[i];
              ^ ~~~~~~~~~~~
2 errors generated.
make[1]: *** [objs/addon/src/ngx_http_echo_request_info.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [install] Error 2

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/shopify/homebrew-shopify/issues


Error: You have MacPorts or Fink installed:
  /opt/local/bin/port

This can cause trouble. You don't have to uninstall them, but you may want to
temporarily move them out of the way, e.g.

  sudo mv /opt/local ~/macports
```