### PR TITLE
Updates lua-upstream-nginx-module to version 0.07

### DIFF
--- a/lua-upstream-nginx-module.rb
+++ b/lua-upstream-nginx-module.rb
@@ -1,18 +1,13 @@
 class LuaUpstreamNginxModule < Formula
   desc "Nginx C module to expose Lua API to ngx_lua for Nginx upstreams"
   homepage "https://github.com/openresty/lua-upstream-nginx-module"
-  url "https://github.com/openresty/lua-upstream-nginx-module/archive/v0.05.tar.gz"
-  sha256 "0fdfb17083598e674680d8babe944f48a9ccd2af9f982eda030c446c93cfe72b"
+  url "https://github.com/openresty/lua-upstream-nginx-module/archive/v0.07.tar.gz"
+  sha256 "2a69815e4ae01aa8b170941a8e1a10b6f6a9aab699dee485d58f021dd933829a"
   head "https://github.com/openresty/lua-upstream-nginx-module.git"
 
   bottle :unneeded
 
   depends_on "lua-nginx-module"
-
-  patch do
-    url "https://gist.githubusercontent.com/csfrancis/4b6ca42b9903f4cef1e05580b2dba1d9/raw/4a64ab78362dfd876c9d4c61f2d11426a4d6de32/current_upstream_name.patch"
-    sha256 "8a36dcca3ed5c3795eb3b635addc1f267a29bd9dcf72a22c56009f6d7f775124"
-  end
 
   def install
     (share+"lua-upstream-nginx-module").install Dir["*"]


### PR DESCRIPTION
@Shopify/edgescale, @Shopify/routing 

See https://github.com/Shopify/nginx-shopify-build/pull/59 for details.