### PR TITLE
change the sha for redshift ssl key

### DIFF
--- a/redshift-ssl.rb
+++ b/redshift-ssl.rb
@@ -2,7 +2,7 @@ class RedshiftSsl < Formula
   desc "Root public key for Amazon redshift SSL connectivity"
   homepage "http://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html#connect-using-ssl"
   url "https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem"
-  sha256 "66fdaaa6ea623fce7052c5b77948d1482317f27076040100167840d3fa2bb449"
+  sha256 "f63b3098250346eee57b63a2b150cb4fd75c3bb70bdd36bc1ac7de6d462499e4"
   version "0.1.0"
 
   def install


### PR DESCRIPTION
```
➜  homebrew-shopify git:(bump-redshift-sha) ✗ curl https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8621  100  8621    0     0  53180      0 --:--:-- --:--:-- --:--:-- 52889
f63b3098250346eee57b63a2b150cb4fd75c3bb70bdd36bc1ac7de6d462499e4  -
```