### PR TITLE
[LuaJIT] Update sha of LuaJIT/issues/180 patch

### DIFF
--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -16,7 +16,7 @@ class LuajitShopify < Formula
   # https://github.com/LuaJIT/LuaJIT/issues/180
   patch do
     url "https://github.com/LuaJIT/LuaJIT/commit/5837c2a2fb1ba6651.diff"
-    sha256 "7b5d233fc3a95437bd1c8459ad35bba63825655f47951b6dba1d053df7f98587"
+    sha256 "622ee354f58d2bde2adbfdf432d4f276ddc83a3b5d11b6cab06fb89f381cfcb3"
   end
 
   deprecated_option "enable-debug" => "with-debug"


### PR DESCRIPTION
I'm not sure why, but the sha of the specific diff seems to have changed. I ran into that issue when setuping my new computer.

```
maximebedard(~/Github/nginx-routing-modules) (refactor-allocator-to-accept-cloud-dcs) > brew install nginx-shopify
==> Installing nginx-shopify from shopify/shopify
==> Installing dependencies for shopify/shopify/nginx-shopify: luajit-shopify, ngx-devel-kit, lua-nginx-module, lua-upstream-nginx-module, lua-nginx-internals-nginx-module, echo-nginx-module
==> Installing shopify/shopify/nginx-shopify dependency: luajit-shopify
==> Downloading http://luajit.org/download/LuaJIT-2.1.0-beta2.tar.gz
Already downloaded: /Users/maximebedard/Library/Caches/Homebrew/luajit-shopify-2.1.0-beta2.tar.gz
==> Downloading https://github.com/LuaJIT/LuaJIT/commit/5837c2a2fb1ba6651.diff
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 7b5d233fc3a95437bd1c8459ad35bba63825655f47951b6dba1d053df7f98587
Actual: 622ee354f58d2bde2adbfdf432d4f276ddc83a3b5d11b6cab06fb89f381cfcb3
Archive: /Users/maximebedard/Library/Caches/Homebrew/luajit-shopify--patch-7b5d233fc3a95437bd1c8459ad35bba63825655f47951b6dba1d053df7f98587.diff
To retry an incomplete download, remove the file above.
```