### PR TITLE
Install Presto 0.182 jdbc drivers and cli

### DIFF
--- a/data-warehouse.rb
+++ b/data-warehouse.rb
@@ -1,0 +1,13 @@
+def get_presto_version
+  "0.182"
+end
+
+def get_redshift_jdbc_driver_version
+  "42-1.2.10.1009"
+end
+
+def datagrip_settings_location
+  settings_location = Dir[File.join("/Users/#{ENV['USER']}", '/Library/Preferences', 'DataGrip*')].sort.last
+  raise "DataGrip Settings folder does not exist." unless settings_location and Dir.exist? settings_location
+  settings_location
+end

--- a/datagrip_settings.rb
+++ b/datagrip_settings.rb
@@ -1,0 +1,90 @@
+require 'erb'
+require_relative 'data-warehouse'
+
+class DatagripSettings < Formula
+  desc "DataGrip Settings to easily connect to the data warehouse"
+  url "https://s3.amazonaws.com/shopify-data-downloads/datagrip_settings.txt"
+  sha256 "afd7386c961137729bada16b7dce6303575f30beaad52a17e8699426c3b94822"
+  homepage "https://vault.shopify.com/data/SQL-Client-Setup"
+  version "1.0"
+
+  @@template_folder = '/usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/templates/datagrip_settings/'
+
+  depends_on "presto-jdbc" => :recommended
+  depends_on "redshift-jdbc" => :recommended
+
+  def install
+    raise 'Please install DataGrip first.' unless is_datagrip_installed?
+
+    template_function_mapping = {
+      "databaseDrivers.xml.erb" => "update_database_drivers_settings",
+      "dataSources.xml.erb" => "update_datasources_settings"
+    }
+
+    template_paths = Dir[File.join(@@template_folder, 'data*')]
+
+    template_paths.each do |template_path|
+      template_filename = File.basename(template_path)
+      function = template_function_mapping[template_filename]
+      self.public_send(function, template_path, template_filename)
+    end
+  end
+
+  def load_template_settings(template)
+    b = binding
+    b.local_variable_set(:presto_version, get_presto_version)
+    b.local_variable_set(:redshift_jdbc_driver_version, get_redshift_jdbc_driver_version)
+    ERB.new(File.read(template)).result(b)
+  end
+
+  def update_database_drivers_settings(template_path, template_filename)
+    made_changes_to_original_settings = false
+    original_settings_path = File.join(datagrip_settings_location, 'options', File.basename(template_filename, '.erb'))
+    original_settings = Hash.from_xml(original_settings_path.read)
+
+    template_settings = Hash.from_xml(load_template_settings(File.join(@@template_folder, template_filename)))
+
+    template_settings['application']['component']['driver'].each do |driver|
+      driver_name = driver['name']
+      original_driver = original_settings['application']['component']['driver'][driver_name]
+
+      if driver['library']['url'] != original_driver['library']['url']
+        original_driver['library']['url'] = driver['library']['url']
+        made_changes_to_original_settings = true
+      end
+    end
+
+    if made_changes_to_original_settings
+      write_xml_file(original_settings_path, settings)
+    end
+  end
+
+  def update_datasources_settings(template_path, template_filename)
+    made_changes_to_original_settings = false
+    original_settings_path = File.join(datagrip_project_location, File.basename(template_filename, '.erb'))
+    original_settings = File.read(original_settings_path)
+
+    template_settings = Hash.from_xml(File.read(File.join(@@template_folder, template_filename)))
+
+    template_settings['application']['component']['data-source'].each do |data_source|
+      if not original_settings['application']['component'].has_key? data_source['name']
+        original_settings['application']['component'] << data_source
+        made_changes_to_original_settings = true
+      end
+    end
+
+    if made_changes_to_original_settings
+      write_xml_file(original_settings_path, settings)
+    end
+  end
+
+  def write_xml_file(file, settings)
+    fh = File.open(file, 'w')
+    #fh.write(settings.to_xml)
+    fh.close
+  end
+
+  def is_datagrip_installed?
+    File.exist?('/Applications/DataGrip.app')
+  end
+end

--- a/presto-cli.rb
+++ b/presto-cli.rb
@@ -1,9 +1,11 @@
+require_relative 'data-warehouse'
+
 class PrestoCli < Formula
   desc "Presto CLI executable to connect and run queries against Presto"
   homepage "https://prestodb.io/docs/current/installation/cli.html"
-  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/0.151/presto-cli-0.151-executable.jar"
-  sha256 "7d8cde7a38080a08425445e200dc7ecb26635204c32769a59277133bf6328fbb"
-  version "0.151"
+  version get_presto_version
+  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/#{version}/presto-cli-#{version}-executable.jar"
+  sha256 "8f6404accc90d372324b5e5abbd95b2ccecea87a4c5c3ef85804452c05679811"
 
   def install
     lib.install "presto-cli-#{version}-executable.jar"

--- a/presto-jdbc.rb
+++ b/presto-jdbc.rb
@@ -1,11 +1,13 @@
+require_relative 'data-warehouse'
+
 class PrestoJdbc < Formula
   desc "JAR file for connecting to Presto over JDBC"
-  homepage "http://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html#connect-using-ssl"
-  url "https://s3.amazonaws.com/shopify-data-downloads/presto-jdbc-0.148-shopify.jar"
-  sha256 "5776c167ec1bfb1aa98ba99746acef49fe6ac8a2ac094104ce745181717bed20"
-  version "0.148-shopify"
+  homepage "https://prestodb.io/docs/current/installation/jdbc.html"
+  version get_presto_version
+  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/#{version}/presto-jdbc-#{version}.jar"
+  sha256 "8b04760c1e07256f664f6091ec72d29b278c5e29f72d57acb31046a64ae483c7"
 
   def install
-    libexec.install "presto-jdbc-#{version}.jar"
+    lib.install "presto-jdbc-#{version}.jar"
   end
 end

--- a/redshift-jdbc.rb
+++ b/redshift-jdbc.rb
@@ -1,0 +1,13 @@
+require_relative 'data-warehouse'
+
+class RedshiftJdbc < Formula
+  desc "JAR file for connecting to Redshift over JDBC"
+  homepage "https://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html"
+  version get_redshift_jdbc_driver_version
+  url "https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC#{version}.jar"
+  sha256 "69516aa831ae3769a468557bde2c17480b719bf9710ae71f07fc8c1a9b7ad59f"
+
+  def install
+    lib.install "RedshiftJDBC#{version}.jar"
+  end
+end

--- a/templates/datagrip_settings/dataSources.xml
+++ b/templates/datagrip_settings/dataSources.xml
@@ -1,0 +1,36 @@
+<application>
+  <component name="dataSourceStorage" format="xml">
+    <data-source source="LOCAL" name="Redshift" uuid="aca15fcb-2ec3-406e-b9cf-040ebef29e5c">
+      <driver-ref>c8f2a82f-0851-4bb9-b5e8-a53daa9f28b5</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://redshift.data.shopify.com:5439/warehouse</jdbc-url>
+      <driver-properties>
+        <property name="ssl" value="true" />
+      </driver-properties>
+    </data-source>
+    <data-source source="LOCAL" name="MySQL - Aggregates Aurora" uuid="4a9b6294-32af-4153-b099-ac5b17777381">
+      <driver-ref>mysql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://aggregates-aurora.data.shopify.com:3306/starscream</jdbc-url>
+      <driver-properties>
+        <property name="autoReconnect" value="true" />
+        <property name="zeroDateTimeBehavior" value="convertToNull" />
+        <property name="tinyInt1isBit" value="false" />
+        <property name="characterEncoding" value="utf8" />
+        <property name="characterSetResults" value="utf8" />
+        <property name="yearIsDateType" value="false" />
+      </driver-properties>
+    </data-source>
+    <data-source source="LOCAL" name="Presto" uuid="75d56f6d-cd76-4bb7-a56d-5391b6ebe873">
+      <driver-ref>01d7217a-711d-421d-99d3-cb47a2426cd8</driver-ref>
+      <synchronize>true</synchronize>
+      <configured-by-url>true</configured-by-url>
+      <jdbc-driver>com.facebook.presto.jdbc.PrestoDriver</jdbc-driver>
+      <jdbc-url>jdbc:presto://ods1.hu131.data-chi.shopify.com:8082</jdbc-url>
+      <default-dialect>PostgreSQL</default-dialect>
+      <vm-options>-Duser.timezone=&quot;UTC&quot;</vm-options>
+    </data-source>
+  </component>
+</application>

--- a/templates/datagrip_settings/databaseDrivers.xml.erb
+++ b/templates/datagrip_settings/databaseDrivers.xml.erb
@@ -1,0 +1,18 @@
+<application>
+  <component name="LocalDatabaseDriverManager" version="141+">
+    <driver id="c8f2a82f-0851-4bb9-b5e8-a53daa9f28b5" name="Redshift" dialect="PostgreSQL" driver-class="com.amazon.redshift.jdbc42.Driver">
+      <option name="auto-commit" value="true" />
+      <option name="auto-sync" value="true" />
+      <library>
+        <url>file://usr/local/Cellar/redshift-jdbc/<%= redshift_jdbc_driver_version %>/RedshiftJDBC<%= redshift_jdbc_driver_version %>.jar</url>
+      </library>
+    </driver>
+    <driver id="01d7217a-711d-421d-99d3-cb47a2426cd8" name="Presto Driver" driver-class="com.facebook.presto.jdbc.PrestoDriver">
+      <option name="auto-commit" value="true" />
+      <option name="auto-sync" value="true" />
+      <library>
+        <url>file://usr/local/Cellar/presto-jdbc/<%= presto_version %>/presto-jdbc-<%= presto_version %>.jar</url>
+      </library>
+    </driver>
+  </component>
+</application>


### PR DESCRIPTION
This upgrades the Presto drivers and cli to the version that is running in production and is part of an attempt to revive https://github.com/Shopify/dataops/tree/master/datagrip-settings

@kmtaylor-github 