### PR TITLE
update redshift-ssl SHA

### DIFF
--- a/redshift-ssl.rb
+++ b/redshift-ssl.rb
@@ -2,7 +2,7 @@ class RedshiftSsl < Formula
   desc "Root public key for Amazon redshift SSL connectivity"
   homepage "http://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html#connect-using-ssl"
   url "https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem"
-  sha256 "f63b3098250346eee57b63a2b150cb4fd75c3bb70bdd36bc1ac7de6d462499e4"
+  sha256 "e77daa6243a940eb2d144d26757135195b4bdefd345c32a064d4ebea02b9f8a1"
   version "0.1.0"
 
   def install


### PR DESCRIPTION
**What:** 
Updates the SHA for the `redshift-ssl` cask. 

**Why:**
Found while onboarding and trying to install the Redshift CA cert: 
```
starscream (master) $ brew install redshift-ssl
==> Installing redshift-ssl from shopify/shopify
==> Downloading https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: f63b3098250346eee57b63a2b150cb4fd75c3bb70bdd36bc1ac7de6d462499e4
Actual: e77daa6243a940eb2d144d26757135195b4bdefd345c32a064d4ebea02b9f8a1
```

And it seems Amazon agrees!
```
$ curl https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8621  100  8621    0     0  23373      0 --:--:-- --:--:-- --:--:-- 23363
e77daa6243a940eb2d144d26757135195b4bdefd345c32a064d4ebea02b9f8a1  -
```

