### PR TITLE
Remove ENV.minimal_optimization from mysql formula

### DIFF
--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -36,10 +36,6 @@ class MysqlClient < Formula
       "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
       "COMMAND libtool -static -o ${TARGET_LOCATION}"
 
-    # Build without compiler or CPU specific optimization flags to facilitate
-    # compilation of gems and other software that queries `mysql-config`.
-    ENV.minimal_optimization
-
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[
       .


### PR DESCRIPTION
This fixes the following error:

```
Installing shopify/shopify/mysql-client
┃    Cloning into '/usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify'...
┃    ==> Installing mysql-client from shopify/shopify
┃    ==> Installing dependencies for shopify/shopify/mysql-client: cmake
┃        Installing cmake dependency for shopify/shopify/mysql-client
┃    ==> Installing shopify/shopify/mysql-client
┃    Warning: Calling ENV.minimal_optimization is deprecated!
┃    There is no replacement.
┃    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/mysql-client.rb:41:in `install'
┃    Please report this to the shopify/shopify tap!
```

A similar fix was applied to `homebrew-core`: https://github.com/Homebrew/homebrew-core/commit/71797376c000217bfdf4bd508f264a1c5a526b42