### PR TITLE
Add formula for libcidr-shopify package

### DIFF
--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -2,11 +2,11 @@ class LibcidrShopify < Formula
   desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
   homepage 'https://www.over-yonder.net/~fullermd/projects/libcidr'
   url 'http://bazaar.launchpad.net/~fullermd/libcidr/trunk/tarball/302'
-  sha256 'cb3c51ffec7c6dd83dca1e7f3a92852e4febd230624e84457c269bec82432719'
+  sha256 '44d99c491a90d01baf0e074f6b5bac48e7eab93e97835819f631ef2a8bd12935'
 
   patch do
-    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/7888c4a21a1e2afcaf0cdff627d5643574d020a0/mac_os_libcidr_support.patch"
-    sha256 "8578885fd5d8a5c5bf64b92283292c568ba8b38bf7d411a79b0533cfee8a546f"
+    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/151aabb91fe183ca3d18521c29f90007aa690592/mac_os_libcidr_support.patch"
+    sha256 "76459e78199b2ea94f0522af24262ea259fb74e5ba38acd9619a58390eafd599"
   end
 
   def install

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -1,18 +1,15 @@
 class LibcidrShopify < Formula
   desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
   homepage 'https://www.over-yonder.net/~fullermd/projects/libcidr'
-  url 'http://bazaar.launchpad.net/~fullermd/libcidr/trunk/tarball/302'
-  sha256 '44d99c491a90d01baf0e074f6b5bac48e7eab93e97835819f631ef2a8bd12935'
+  url 'https://www.over-yonder.net/~fullermd/projects/libcidr/libcidr-1.2.3.tar.xz'
+  sha256 'afbe266a9839775a21091b0e44daaf890a46ea4c2d3f5126b3048d82b9bfbbc4'
 
-  # This patch can be viewed and edited via https://gist.github.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8
-  # This path can also be accessed via homebrew-shopify/patch/mac_os_libcidr_support.patch
   patch do
-    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/151aabb91fe183ca3d18521c29f90007aa690592/mac_os_libcidr_support.patch"
-    sha256 "76459e78199b2ea94f0522af24262ea259fb74e5ba38acd9619a58390eafd599"
+    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/cd2d5d2c3737f585fc71226786ea82279bf36645/mac_os_libcidr_support.patch"
+    sha256 "92b72bdc3fab7c95f3689d451d67848b1c4d1d9da58561e3db6e3d5ca57cb399"
   end
 
   def install
-    Dir.chdir("./libcidr/trunk")
     system "./mkgmake.sh"
     system "make"
     lib.install "./src/libcidr.dylib"

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -1,10 +1,17 @@
 class LibcidrShopify < Formula
   desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
   homepage 'https://github.com/Shopify/libcidr-shopify/'
-  url 'https://github.com/Shopify/libcidr-shopify/archive/v1.0.0.tar.gz'
-  sha256 '718fbb00ab1ae8f9e692ce6f917ee7b485420df1e05537f8ab871de6a667915d'
+  url 'http://bazaar.launchpad.net/~fullermd/libcidr/trunk/tarball/302'
+  sha256 'cb3c51ffec7c6dd83dca1e7f3a92852e4febd230624e84457c269bec82432719'
+
+  patch do
+    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/fb499d61e4645c04195a84deb293b2f7a2a4720e/mac_os_libcidr_support.patch"
+    sha256 "b0400ea3bff166c189365c283874e0ff8888a6db89f7a0c541eff88dcd1f2b84"
+  end
 
   def install
+    Dir.chdir("./libcidr/trunk")
+    system "./mkgmake.sh"
     system "make"
     lib.install "./src/libcidr.dylib"
     lib.install "./src/libcidr.dylib.0"

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -5,8 +5,8 @@ class LibcidrShopify < Formula
   sha256 'afbe266a9839775a21091b0e44daaf890a46ea4c2d3f5126b3048d82b9bfbbc4'
 
   patch do
-    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/cd2d5d2c3737f585fc71226786ea82279bf36645/mac_os_libcidr_support.patch"
-    sha256 "92b72bdc3fab7c95f3689d451d67848b1c4d1d9da58561e3db6e3d5ca57cb399"
+    url "https://raw.githubusercontent.com/Shopify/homebrew-shopify/3b468e634f3084d1ad2eed26d8b24fd2c61bfbfe/patch/mac_os_libcidr_support.patch"
+    sha256 "fac7310e3dda9ac2a7fc4abd435f1ddcd2300191523b7a83bf2b9eaa683a1271"
   end
 
   def install

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -1,12 +1,12 @@
 class LibcidrShopify < Formula
   desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
-  homepage 'https://github.com/Shopify/libcidr-shopify/'
+  homepage 'https://www.over-yonder.net/~fullermd/projects/libcidr'
   url 'http://bazaar.launchpad.net/~fullermd/libcidr/trunk/tarball/302'
   sha256 'cb3c51ffec7c6dd83dca1e7f3a92852e4febd230624e84457c269bec82432719'
 
   patch do
-    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/fb499d61e4645c04195a84deb293b2f7a2a4720e/mac_os_libcidr_support.patch"
-    sha256 "b0400ea3bff166c189365c283874e0ff8888a6db89f7a0c541eff88dcd1f2b84"
+    url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/7888c4a21a1e2afcaf0cdff627d5643574d020a0/mac_os_libcidr_support.patch"
+    sha256 "8578885fd5d8a5c5bf64b92283292c568ba8b38bf7d411a79b0533cfee8a546f"
   end
 
   def install

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -4,6 +4,8 @@ class LibcidrShopify < Formula
   url 'http://bazaar.launchpad.net/~fullermd/libcidr/trunk/tarball/302'
   sha256 '44d99c491a90d01baf0e074f6b5bac48e7eab93e97835819f631ef2a8bd12935'
 
+  # This patch can be viewed and edited via https://gist.github.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8
+  # This path can also be accessed via homebrew-shopify/patch/mac_os_libcidr_support.patch
   patch do
     url "https://gist.githubusercontent.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8/raw/151aabb91fe183ca3d18521c29f90007aa690592/mac_os_libcidr_support.patch"
     sha256 "76459e78199b2ea94f0522af24262ea259fb74e5ba38acd9619a58390eafd599"

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -1,12 +1,11 @@
 class LibcidrShopify < Formula
   desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
   homepage 'https://github.com/Shopify/libcidr-shopify/'
-  url 'https://github.com/Shopify/libcidr-shopify/archive/v1.1.0.tar.gz'
-  sha256 'ba1fc083dbf39a902bf17add9628b3e5b988385d7a1e8006293372e1094f11e6'
+  url 'https://github.com/Shopify/libcidr-shopify/archive/v1.0.0.tar.gz'
+  sha256 '718fbb00ab1ae8f9e692ce6f917ee7b485420df1e05537f8ab871de6a667915d'
 
   def install
     system "make"
-    system "make", "install"
     lib.install "./src/libcidr.dylib"
     lib.install "./src/libcidr.dylib.0"
   end

--- a/libcidr-shopify.rb
+++ b/libcidr-shopify.rb
@@ -1,0 +1,13 @@
+class LibcidrShopify < Formula
+  desc 'Libcidr is a library that provides utility functions to handle IP addresses and net blocks.'
+  homepage 'https://github.com/Shopify/libcidr-shopify/'
+  url 'https://github.com/Shopify/libcidr-shopify/archive/v1.1.0.tar.gz'
+  sha256 'ba1fc083dbf39a902bf17add9628b3e5b988385d7a1e8006293372e1094f11e6'
+
+  def install
+    system "make"
+    system "make", "install"
+    lib.install "./src/libcidr.dylib"
+    lib.install "./src/libcidr.dylib.0"
+  end
+end

--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -21,6 +21,7 @@ class NginxShopify < Formula
   depends_on "geoip"
   depends_on "openssl"
   depends_on "luajit-shopify"
+  depends_on "libcidr-shopify"
   nginx_modules.each { |m, v| depends_on m => v }
 
   # This patch can be viewed and edited via https://gist.github.com/marc-barry/63b7bc9481d73211a895efcb1b98b22e

--- a/patch/mac_os_libcidr_support.patch
+++ b/patch/mac_os_libcidr_support.patch
@@ -1,0 +1,49 @@
+diff --git a/libcidr/trunk/Makefile b/libcidr/trunk/Makefile
+index c72131f..46adb34 100644
+--- a/libcidr/trunk/Makefile
++++ b/libcidr/trunk/Makefile
+@@ -70,7 +70,7 @@ install-examples:
+
+ # Wrapup install of everything
+ install: install-lib install-dev install-cidrcalc \
+-  install-man install-docs install-examples
++  install-man install-examples
+ 	@${ECHO} ""
+ 	@${ECHO} "libcidr install complete"
+
+diff --git a/libcidr/trunk/Makefile.inc b/libcidr/trunk/Makefile.inc
+index 3c44a94..108fb31 100644
+--- a/libcidr/trunk/Makefile.inc
++++ b/libcidr/trunk/Makefile.inc
+@@ -2,8 +2,8 @@
+
+ # Library naming and versioning
+ LIB_VERS = 0
+-SHLIB_NAME = libcidr.so.${LIB_VERS}
+-SHLIB_LINK = libcidr.so
++SHLIB_LINK = libcidr.dylib
++SHLIB_NAME = ${SHLIB_LINK}.${LIB_VERS}
+
+ # Define some destination directories
+ # Where we think of ourselves as living
+diff --git a/libcidr/trunk/src/Makefile.inc b/libcidr/trunk/src/Makefile.inc
+index 7300414..089fd2b 100644
+--- a/libcidr/trunk/src/Makefile.inc
++++ b/libcidr/trunk/src/Makefile.inc
+@@ -45,7 +45,7 @@ def: all
+
+ ${SHLIB_NAME}: ${SO_FILES}
+ 	@echo Linking ${SHLIB_NAME}...
+-	${CC} -shared -Wl,-x -o ${@} -Wl,-soname,${SHLIB_NAME} \
++	${CC} -shared -Wl,-x -o ${@} -Wl,-install_name,${SHLIB_NAME} \
+ 			`${LORDER} ${SO_FILES} | ${TSORT}`
+ 	${LN} -sf ${SHLIB_NAME} ${SHLIB_LINK}
+
+@@ -70,7 +70,7 @@ clean allclean:
+ # These paths wind up relative to src/{test,examples}/*
+ CFLAGS += -I../../../include
+ L_FLAGS += -g -pipe -L../..
+-LCIDR = ../../libcidr.so
++LCIDR = ../../${SHLIB_LINK}
+
+ CLEAN_FILES = ${O_FILES} ${PROGNAME} *core .depend

--- a/patch/mac_os_libcidr_support.patch
+++ b/patch/mac_os_libcidr_support.patch
@@ -1,7 +1,7 @@
-diff --git a/libcidr/trunk/Makefile b/libcidr/trunk/Makefile
+diff --git a/Makefile b/Makefile
 index c72131f..46adb34 100644
---- a/libcidr/trunk/Makefile
-+++ b/libcidr/trunk/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -70,7 +70,7 @@ install-examples:
 
  # Wrapup install of everything
@@ -11,10 +11,10 @@ index c72131f..46adb34 100644
  	@${ECHO} ""
  	@${ECHO} "libcidr install complete"
 
-diff --git a/libcidr/trunk/Makefile.inc b/libcidr/trunk/Makefile.inc
+diff --git a/Makefile.inc b/Makefile.inc
 index 3c44a94..108fb31 100644
---- a/libcidr/trunk/Makefile.inc
-+++ b/libcidr/trunk/Makefile.inc
+--- a/Makefile.inc
++++ b/Makefile.inc
 @@ -2,8 +2,8 @@
 
  # Library naming and versioning
@@ -26,10 +26,10 @@ index 3c44a94..108fb31 100644
 
  # Define some destination directories
  # Where we think of ourselves as living
-diff --git a/libcidr/trunk/src/Makefile.inc b/libcidr/trunk/src/Makefile.inc
-index 7300414..089fd2b 100644
---- a/libcidr/trunk/src/Makefile.inc
-+++ b/libcidr/trunk/src/Makefile.inc
+diff --git a/src/Makefile.inc b/src/Makefile.inc
+index 653357b..e6ca131 100644
+--- a/src/Makefile.inc
++++ b/src/Makefile.inc
 @@ -45,7 +45,7 @@ def: all
 
  ${SHLIB_NAME}: ${SO_FILES}


### PR DESCRIPTION
Create a homebrew formula for the libcidr-shopify utility library (https://github.com/Shopify/libcidr-shopify) @Shopify/edgescale 


link to patch gist: https://gist.github.com/fmejia97/ad72a1f2b5d4b77a2921f32d861850b8