### PR TITLE
Update MySQL-Client URL

### DIFF
--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -1,7 +1,7 @@
 class MysqlClient < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
-  url "http://pkgs.fedoraproject.org/repo/pkgs/community-mysql/mysql-5.7.10.tar.gz/aabc96e8628228014479f7233d076877/mysql-5.7.10.tar.gz"
+  url "https://src.fedoraproject.org/repo/pkgs/community-mysql/mysql-5.7.10.tar.gz/aabc96e8628228014479f7233d076877/mysql-5.7.10.tar.gz"
   sha256 "1ea1644884d086a23eafd8ccb04d517fbd43da3a6a06036f23c5c3a111e25c74"
 
   bottle do


### PR DESCRIPTION
The old path for this formula no longer works: it's throwing HTTP/403 errors that cause "dev up" to fail for Shopify-core.

http://pkgs.fedoraproject.org/repo/pkgs/community-mysql/mysql-5.7.10.tar.gz/aabc96e8628228014479f7233d076877/mysql-5.7.10.tar.gz

```
$ dev up --verbose
┏━━ Fetch web ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃                                                                                                                                                                                           100.0%
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.6s) ━━
⭑  1/18 Prerequisites
⭑  2/18 { web } Railgun
⭑  3/18 { web } Node
⭑  4/18 { web } Homebrew Packages
⭑  5/18 { web } Git Hooks
⭑  6/18 Prerequisites
┏━━ 👩‍💻  7/18 Integrations ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ 𝒾 Start dev sv processes for enabled integrations
┃ ✓ waiting for server in project: web
┃ ✓ Start dev sv processes for enabled integrations: done
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.11s) ━━
┏━━ 👩‍💻  8/18 Homebrew Packages ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ⭑ install homebrew
┃ ⭑ upgrade bash
┃ ⭑ unlink conflicting homebrew packages
┃ 𝒾 install packages
┃ running brew update
┃ We need to install 1 package(s): shopify/shopify/mysql-client
┃ Installing shopify/shopify/mysql-client
┃    ==> Installing mysql-client from shopify/shopify
┃    curl: (22) The requested URL returned error: 403 
┃    Forbidden
┃    Error: Failed to download resource "mysql-client"
┃    Download failed: http://pkgs.fedoraproject.org/repo/pkgs/community-mysql/mysql-5.7.10.tar.gz/aabc96e8628228014479f7233d076877/mysql-5.7.10.tar.gz
┃ ✗ install packages: failed!
┃ ✗ Error Reason:
┃ ✗   Homebrew packages shopify/shopify/mysql-client were not installed properly
┗━━ 🤷  Failed! Aborting! ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (4.27s) ━━

🤷  install packages: failed!
(Run dev troubleshoot for troubleshooting tips.)
```

I thought it would be as simple as updating the protocol to HTTPS but it's a little more subtle, there's a 302 redirect to a new host: src.fedoraproject.org


This PR should update the URL used by MySQL-Client (but not the SHA256 hash, so we can be confident it's the same file) so that the gem can be installed.

I tested this by running `brew edit shopify/shopify/mysql`, making the above update, and then running `dev up` which completed the home brew dependency installation successfully.