### PR TITLE
Fix "<<-EOS.undent" deprecation warning

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -25,7 +25,7 @@ class Toxiproxy < Formula
 
   plist_options :manual => "toxiproxy"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
Close https://github.com/Shopify/homebrew-shopify/issues/89

Tested by making this change locally with `brew edit toxiproxy`. After that, `brew info toxiproxy` doesn't display any warnings.