### PR TITLE
Replace undent heredocs with Ruby 2.3 native heredocs

### DIFF
--- a/cmake30.rb
+++ b/cmake30.rb
@@ -7,7 +7,7 @@ class NoExpatFramework < Requirement
     !File.exist? expat_framework
   end
 
-  def message; <<-EOS.undent
+  def message; <<~EOS
     Detected #{expat_framework}
 
     This will be picked up by CMake's build system and likely cause the

--- a/cmake30.rb
+++ b/cmake30.rb
@@ -32,7 +32,7 @@ class Cmake30 < Formula
   end
 
   option "without-docs", "Don't build man pages"
-  depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
+  depends_on "python" => :build if MacOS.version <= :snow_leopard && build.with?("docs")
 
   depends_on "qt" => :optional
 

--- a/cs-openssl.rb
+++ b/cs-openssl.rb
@@ -132,7 +132,7 @@ class CsOpenssl < Formula
     (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     A CA file has been bootstrapped using certificates from the system
     keychain. To add additional certificates, place .pem files in
       #{openssldir}/certs

--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -57,7 +57,7 @@ class LuajitShopify < Formula
   end
 
   test do
-    system "#{bin}/luajit", "-e", <<-EOS.undent
+    system "#{bin}/luajit", "-e", <<~EOS
       local ffi = require("ffi")
       ffi.cdef("int printf(const char *fmt, ...);")
       ffi.C.printf("Hello %s!\\n", "#{ENV["USER"]}")

--- a/presto-cli.rb
+++ b/presto-cli.rb
@@ -13,7 +13,7 @@ class PrestoCli < Formula
     bin.install "presto"
   end
 
-  def wrapper_script; <<-EOS.undent
+  def wrapper_script; <<~EOS
     #!/bin/bash
 
     java -Duser.timezone=UTC -jar #{lib}/presto-cli-#{version}-executable.jar --user $(whoami) --server ods1.hu131.data-chi.shopify.com:8082 "$@"

--- a/shopify-graphicsmagick.rb
+++ b/shopify-graphicsmagick.rb
@@ -90,7 +90,7 @@ class ShopifyGraphicsmagick < Formula
 
   def caveats
     if build.with? "perl"
-      <<-EOS.undent
+      <<~EOS
         The Graphics::Magick perl module has been installed under:
 
           #{lib}

--- a/shopify-libgraphqlparser.rb
+++ b/shopify-libgraphqlparser.rb
@@ -34,7 +34,7 @@ class ShopifyLibgraphqlparser < Formula
   test do
     require "utils/json"
 
-    sample_query = <<-EOS.undent
+    sample_query = <<~EOS
       { user }
     EOS
 

--- a/shopify-ruby.rb
+++ b/shopify-ruby.rb
@@ -113,7 +113,7 @@ class ShopifyRuby < Formula
     "#{HOMEBREW_PREFIX}/bin"
   end
 
-  def rubygems_config; <<-EOS.undent
+  def rubygems_config; <<~EOS
     module Gem
       class << self
         alias :old_default_dir :default_dir

--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -25,7 +25,7 @@ class Toxiproxy < Formula
 
   plist_options :manual => "toxiproxy"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
Homebrew has deprecated its `.undent` helper now that all Homebrew installations use Ruby 2.3. Ruby 2.3 includes a native version of this form of heredoc, the squiggly heredoc (`<<~EOS`). Homebrew will print deprecation warnings for all of these and, for users running with the Homebrew developer mode on, will refuse to run the method entirely.

This supersedes #91, which only updated one formula, and fixes #89.

cc @fmejia97 and @jules2689, who updated these most recently.