### PR TITLE
Create casks/tunnel-client-app.rb to install Tunnel Client App

### DIFF
--- a/casks/tunnel-client-app.rb
+++ b/casks/tunnel-client-app.rb
@@ -1,8 +1,8 @@
 cask 'tunnel-client-app' do
-  version '1.0.0'
-  sha256 'bc8dcb14d803e098facb1373e37123bcd74a24cc2667167c7953a09f3819e985'
+  version '0.1.0'
+  sha256 'ef1398a235b6e1d7ad2fd7e0a9d5dbf3d1b5a086bb171cc615943bae244fea29'
 
-  url 'https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app.tar.gz'
+  url 'https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app-c1382d0e6f4607b9739a0422468000536491f0e8.tar.gz'
   name 'Tunnel Client App'
   homepage 'https://github.com/Shopify/tunnel-client-app'
 

--- a/casks/tunnel-client-app.rb
+++ b/casks/tunnel-client-app.rb
@@ -1,0 +1,10 @@
+cask 'tunnel-client-app' do
+  version '1.0.0'
+  sha256 'bc8dcb14d803e098facb1373e37123bcd74a24cc2667167c7953a09f3819e985'
+
+  url 'https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app.tar.gz'
+  name 'Tunnel Client App'
+  homepage 'https://github.com/Shopify/tunnel-client-app'
+
+  app 'TunnelClient.app'
+end


### PR DESCRIPTION
After this change, users that have the Shopify brew tap can install the Tunnel Client App (a macOS application that wraps the `oauth-tunnel-client`).

Homebrew Cask is the way to install applications (e.g. google chrome, IDEs, macOS apps, etc).

```shell
brew tap shopify/shopify # get Shopify's brew tap
brew cask install tunnel-client-app # install the Tunnel Client App to /Applications
```

Running `brew cask install tunnel-client-app`:
```shell
$ brew cask install tunnel-client-app
==> Satisfying dependencies
==> Downloading https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app.tar.gz
Already downloaded: /Users/nicholaswu/Library/Caches/Homebrew/Cask/tunnel-client-app--1.0.0.tar.gz
==> Verifying checksum for Cask tunnel-client-app
==> Installing Cask tunnel-client-app
==> Moving App 'TunnelClient.app' to '/Applications/TunnelClient.app'.
🍺  tunnel-client-app was successfully installed!
```

<details>
<summary>Resources</summary>

https://github.com/caskroom/homebrew-cask
https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md
https://vanwollingen.nl/distributing-private-tools-through-homebrew-d046761fb3a1
</details>