### PR TITLE
Update oauth-tunnel-client.rb to 0.2.1

### DIFF
--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -8,7 +8,7 @@ class OauthTunnelClient < Formula
   desc 'Create a secure local proxy with Shopify GCP services'
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
   url 'https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-b1dfd5b0f7d9c5abd0601192e1132fc03b1676f1.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1521647008&Signature=mPFZIYx069THKCQzm7VULjH6WRS0cbsn2x%2Fbt34zEKCseze3xlgiYgK1gr5LOjw4kXO3Cds7eEISoo5iQP8mqJfqZo3d2d3Od2%2Fw8coTn9ubb%2BXCEPYzBKhVxsz1XwVD1XZz4VjxA1gqWnz4fYHPxjseAIvTJkySmirday9EVcY2iUM5AY3v4MFxiJiYas7ngSwkHA5SeToo%2Fq1d%2B%2BO3IqkEmgLrT2J5TU%2FcPqnzPybiQg4rvhCZ7dmv3Fpdooyl4aAQxvo6zDjrwNSFjr2ARnoFiSzTmxiaPfpQtbnIfmSCVBcvRie%2Bn7NkvzbJDqxQtXw7NlcOAWyoPwfhMg73oA%3D%3D', using: GoogleStorageDownloadStrategy 
-  sha256 '40e8d8de95cbfd19fe61278cbcc0e6c937670d7bdb7924110d2d222080b53e3a'
+  sha256 '5792276bab2151408320f10d5b85480e52a3d95eaff260eb2577d8288bdade44'
   version "0.2.1"
 
   def install

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -7,9 +7,9 @@ class OauthTunnelClient < Formula
 
   desc 'Create a secure local proxy with Shopify GCP services'
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
-  url 'https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-3e10de5ca59b881acd691dc4022b052a77d44504.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1522076325&Signature=vSUnV1BKINiQvl38EULEw7eKVb0ju0yRd47BpSX%2FKUITS8jtvMBw35ug1%2FH9PBN%2BJRmNeR5PdZTUYWjHu6nxBSl1MqOUlfSKSSk%2Brv5kmaojX%2FibDA31da6MorBQ6i%2FgBE%2F4rVr93lxkSX%2Bz7siZWOEMvLTM3L3Zw%2BGecwOyGpscHhTm76YphBM8cI%2BB%2BzyI2i5djA6%2Bt0scQt%2Bmh%2B1RxLg0nIgxksP%2FzTGkkBwuvjb4nsj%2BGEC2FGCIkxUAYeeT5eJoOPfA2g02n1ZH7duS%2Fh6mnJcydRdzbIVxq8PWwox%2F7HcWDKXD082%2BLjK3RgKi7jC3qGUUGLE8%2BEltmd%2BtvQ%3D%3D', using: GoogleStorageDownloadStrategy 
-  sha256 '02e45f457e1626a4dee7999f432afae6bf7cafa41dd414afa8b690a39f9ff94a'
-  version "0.2.0"
+  url 'https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-b1dfd5b0f7d9c5abd0601192e1132fc03b1676f1.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1521647008&Signature=mPFZIYx069THKCQzm7VULjH6WRS0cbsn2x%2Fbt34zEKCseze3xlgiYgK1gr5LOjw4kXO3Cds7eEISoo5iQP8mqJfqZo3d2d3Od2%2Fw8coTn9ubb%2BXCEPYzBKhVxsz1XwVD1XZz4VjxA1gqWnz4fYHPxjseAIvTJkySmirday9EVcY2iUM5AY3v4MFxiJiYas7ngSwkHA5SeToo%2Fq1d%2B%2BO3IqkEmgLrT2J5TU%2FcPqnzPybiQg4rvhCZ7dmv3Fpdooyl4aAQxvo6zDjrwNSFjr2ARnoFiSzTmxiaPfpQtbnIfmSCVBcvRie%2Bn7NkvzbJDqxQtXw7NlcOAWyoPwfhMg73oA%3D%3D', using: GoogleStorageDownloadStrategy 
+  sha256 '40e8d8de95cbfd19fe61278cbcc0e6c937670d7bdb7924110d2d222080b53e3a'
+  version "0.2.1"
 
   def install
     bin.install({'oauth-tunnel-client_darwin_amd64' => 'oauth-tunnel-client'})


### PR DESCRIPTION
Get the latest changes to `oauth-tunnel-client` including new endpoint `/api/status`.

Will also update the clients of this brew package.

Success logs:
```
$ brew upgrade oauth-tunnel-client
^C==> Upgrading 1 outdated package, with result:
shopify/shopify/oauth-tunnel-client 0.2.1
==> Upgrading shopify/shopify/oauth-tunnel-client
==> Downloading https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-b1dfd5b0f7d9c5abd0601192e1132fc03b1676f1.tar.gz?GoogleAccessId=pipa-production@sh
######################################################################## 100.0%
chmod 750 /usr/local/var/log/oauth-tunnel-client/
==> Caveats
To have launchd start shopify/shopify/oauth-tunnel-client now and restart at login:
  brew services start shopify/shopify/oauth-tunnel-client
==> Summary
🍺  /usr/local/Cellar/oauth-tunnel-client/0.2.1: 4 files, 16.3MB, built in 3 seconds
```