### PR TITLE
Update oauth-tunnel-client URL for v0.2.1

### DIFF
--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -7,7 +7,7 @@ class OauthTunnelClient < Formula
 
   desc 'Create a secure local proxy with Shopify GCP services'
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
-  url 'https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-b1dfd5b0f7d9c5abd0601192e1132fc03b1676f1.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1521647008&Signature=mPFZIYx069THKCQzm7VULjH6WRS0cbsn2x%2Fbt34zEKCseze3xlgiYgK1gr5LOjw4kXO3Cds7eEISoo5iQP8mqJfqZo3d2d3Od2%2Fw8coTn9ubb%2BXCEPYzBKhVxsz1XwVD1XZz4VjxA1gqWnz4fYHPxjseAIvTJkySmirday9EVcY2iUM5AY3v4MFxiJiYas7ngSwkHA5SeToo%2Fq1d%2B%2BO3IqkEmgLrT2J5TU%2FcPqnzPybiQg4rvhCZ7dmv3Fpdooyl4aAQxvo6zDjrwNSFjr2ARnoFiSzTmxiaPfpQtbnIfmSCVBcvRie%2Bn7NkvzbJDqxQtXw7NlcOAWyoPwfhMg73oA%3D%3D', using: GoogleStorageDownloadStrategy 
+  url 'https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-3d598b521f6a38a0e520abcb88861a2f19612138.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1538846760&Signature=ZFurNLDuykVYAmETTYbe139u9tAGnNGtTrT7EE4S3F90AA15bQtAzUHh6XW9AbEuVyGlvIYP2LDHi7FejgVW7c5e%2BeaoqLeTlSFy8bIz9i8tZUyVMu3frHMt%2BvGVLZfVVj%2BgcBvuB79HGEJvzTjc1UKfDpzXnRWR8TytajSy9FsSrtEuhIc7Kpj8rvaX41MfX3996%2Bnj%2BMVfNVwM64CBTDgttgl2FtxxCTFK6wNa8U4RR9UCyBbGQ6hFVdSuXYxwViPanjqawVyJPzGzQKkPAaeVswfQHscWb0s%2FfGjIt0KBOAtU%2Bad0BC7O17Anu7Qtg9ETmkzgvL3KQRoavMLf1A%3D%3D', using: GoogleStorageDownloadStrategy
   sha256 '5792276bab2151408320f10d5b85480e52a3d95eaff260eb2577d8288bdade44'
   version "0.2.1"
 


### PR DESCRIPTION
Missed the URL in the last commit at #97 