### PR TITLE
Update presto server from DC to GCP

### DIFF
--- a/presto-cli.rb
+++ b/presto-cli.rb
@@ -16,7 +16,7 @@ class PrestoCli < Formula
   def wrapper_script; <<~EOS
     #!/bin/bash
 
-    java -Duser.timezone=UTC -jar #{lib}/presto-cli-#{version}-executable.jar --user $(whoami) --server ods1.hu131.data-chi.shopify.com:8082 "$@"
+    java -Duser.timezone=UTC -jar #{lib}/presto-cli-#{version}-executable.jar --user $(whoami) --server presto-for-datachi.presto.tunnel.shopifykloud.com:8675 "$@"
     EOS
   end
 end


### PR DESCRIPTION
This PR updates the homebrew presto_cli formula to support the new presto GCP cluster instead of the DC cluster.

Tested via `brew install https://raw.githubusercontent.com/Shopify/homebrew-shopify/update-presto-gcp/presto-cli.rb`

Alternatively, if one still wants to use the old DC presto server you can specify server url when you invoke the cli, ie: `$ presto --server ods1.hu131.data-chi.shopify.com:8082`

@alanctgardner @andrewryder @cfournie for review