### PR TITLE
Bump to NGINX version 1.13.9

### DIFF
--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -1,8 +1,8 @@
 class NginxShopify < Formula
   desc "HTTP(S) server, reverse proxy, IMAP/POP3 proxy server"
   homepage "http://nginx.org/"
-  url "https://nginx.org/download/nginx-1.13.5.tar.gz"
-  sha256 "0e75b94429b3f745377aeba3aff97da77bf2b03fcb9ff15b3bad9b038db29f2e"
+  url "https://nginx.org/download/nginx-1.13.9.tar.gz"
+  sha256 "5faea18857516fe68d30be39c3032bd22ed9cf85e1a6fdf32e3721d96ff7fa42"
   head "http://hg.nginx.org/nginx/", :using => :hg
 
   conflicts_with "nginx", :because => "shopify has a custom nginx build. `brew uninstall nginx` first"


### PR DESCRIPTION
Related: https://github.com/Shopify/nginx-shopify-build/pull/82, https://github.com/Shopify/cookbooks/pull/16271, https://github.com/Shopify/shopify-docker-images/pull/671

Matches us with https://github.com/Shopify/nginx-shopify-build/pull/82 and https://github.com/Shopify/nginx-shopify-build/pull/82.