### PR TITLE
Add tunnel-client-app depends_on oauth-tunnel-client

### DIFF
--- a/casks/tunnel-client-app.rb
+++ b/casks/tunnel-client-app.rb
@@ -2,6 +2,7 @@ cask 'tunnel-client-app' do
   version '0.1.0'
   sha256 '562ff71232d120ae64e2be9f683296687d8a1c5f9e1cfb3d8ee315b1e57ac205'
 
+  depends_on formula: 'oauth-tunnel-client'
   url 'https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app-430b1d1967a808ad919f43a3617bb74f595bb528.tar.gz'
   name 'Tunnel Client App'
   homepage 'https://github.com/Shopify/tunnel-client-app'


### PR DESCRIPTION
### Why
Since `tunnel-client-app` requires the `oauth-tunnel-client` to be running in the background, let's install `oauth-tunnel-client` if needed when installing `tunnel-client-app`.

Success Logs:
```
$ brew cask install tunnel-client-app
==> Satisfying dependencies
==> Installing Formula dependencies: oauth-tunnel-client
==> Installing shopify/shopify/oauth-tunnel-client
==> Downloading https://storage.googleapis.com/oauth-tunnel-binaries/oauth-tunnel-client-binaries-3d598b521f6a38a0e520abcb88861a2f19612138.tar.gz?GoogleAccessId=pipa-production@shopify-docker-images.iam.gserviceaccount.com&Expires=1538846760&Signature=ZFurNLDuykVYAmETTYbe139u9tAGnNGtTrT7EE4S3F90AA15bQtAzUHh6XW9AbEuVyGlvIYP2LDHi7FejgVW7c5e%2BeaoqLeTlSFy8bIz9i8tZUyVMu3frHMt%2BvGVLZfVVj%2BgcBvuB79HGEJvzTjc1UKfDpzXnRWR8TytajSy9FsSrtEuhIc7Kpj8rvaX41MfX3996%2Bnj%2BMVfNVwM64CBTDgttgl2FtxxCTFK6wNa8U4RR9UCyBbGQ6hFVdSuXYxwViPanjqawVyJPzGzQKkPAaeVswfQHscWb0s%2FfGjIt0KBOAt
######################################################################## 100.0%
chmod 750 /usr/local/var/log/oauth-tunnel-client/
==> Caveats
To have launchd start shopify/shopify/oauth-tunnel-client now and restart at login:
  brew services start shopify/shopify/oauth-tunnel-client
==> Summary
🍺  /usr/local/Cellar/oauth-tunnel-client/0.2.1: 4 files, 16.3MB, built in 4 seconds
==> Downloading https://storage.googleapis.com/tunnel-client-app-binaries/TunnelClient.app-430b1d1967a808ad919f43a3617bb74f595bb528.tar.gz
######################################################################## 100.0%
==> Verifying checksum for Cask tunnel-client-app
==> Installing Cask tunnel-client-app
==> Moving App 'TunnelClient.app' to '/Applications/TunnelClient.app'.
🍺  tunnel-client-app was successfully installed!
```