### PR TITLE
Get luajit-shopify building again on High Sierra

### DIFF
--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -33,6 +33,10 @@ class LuajitShopify < Formula
       f.change_make_var! "CCOPT_x86", ""
     end
 
+    # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
+    # is not set then it's forced to 10.4, which breaks compile on Mojave.
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+
     ENV.O2 # Respect the developer's choice.
 
     args = %W[PREFIX=#{prefix}]


### PR DESCRIPTION
After applying this change locally, I was able to build luajit-shopify on High Sierra. I stole this change from the default `luajit` Formula:

https://github.com/Homebrew/homebrew-core/blob/1cfa45642ba20143d8606a069621a534a19d2ac0/Formula/luajit.rb#L29-L33