### PR TITLE
Add phantomjs cask to Shopify tap

### DIFF
--- a/casks/phantomjs.rb
+++ b/casks/phantomjs.rb
@@ -1,0 +1,11 @@
+cask 'phantomjs' do
+  version '2.1.1'
+  sha256 '538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1'
+
+  # bitbucket.org/ariya/phantomjs was verified as official when first introduced to the cask
+  url "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-#{version}-macosx.zip"
+  name 'PhantomJS'
+  homepage 'http://phantomjs.org/'
+
+  binary "phantomjs-#{version}-macosx/bin/phantomjs"
+end


### PR DESCRIPTION
So Homebrew `phantomjs` build is FUBAR'd as with most recent XCode/CLT it does not build on macOS High Sierra and Mojave.

See https://github.com/Homebrew/homebrew-core/issues/32402 and https://github.com/Homebrew/homebrew-cask/pull/52595.

While it seems like there's a chance that `phantomjs` will be added to upstream Cask repo, it seems like some maintainers are not very fond of having abandonware in Homebrew and suggest to move it to our own tap instead:

> Phantomjs is abandoned software. We don’t really like keeping those. You may wish to consider hosting your own tap for it.

cc: @Shopify/datadelivery @Shopify/dev-acceleration 