### PR TITLE
Add SHA256 check to docker-ssh-agent-forward.rb

### DIFF
--- a/docker-ssh-agent-forward.rb
+++ b/docker-ssh-agent-forward.rb
@@ -2,6 +2,8 @@ class DockerSshAgentForward < Formula
   desc "Forward SSH agent socket into a container"
   homepage "https://github.com/avsm/docker-ssh-agent-forward"
   head "https://github.com/avsm/docker-ssh-agent-forward.git"
+  url "https://github.com/avsm/docker-ssh-agent-forward/archive/master.tar.gz"
+  sha256 "3f6b11c72fe26a7228074d453bf13c54d03be09a11a7e8f1277c6ec9a411ecda"
 
   def install
     ENV['PATH']   = "#{ENV['PATH']}:/usr/local/bin"

--- a/docker-ssh-agent-forward.rb
+++ b/docker-ssh-agent-forward.rb
@@ -1,9 +1,9 @@
 class DockerSshAgentForward < Formula
   desc "Forward SSH agent socket into a container"
-  homepage "https://github.com/avsm/docker-ssh-agent-forward"
-  head "https://github.com/avsm/docker-ssh-agent-forward.git"
-  url "https://github.com/avsm/docker-ssh-agent-forward/archive/master.tar.gz"
-  sha256 "3f6b11c72fe26a7228074d453bf13c54d03be09a11a7e8f1277c6ec9a411ecda"
+  homepage "https://github.com/Shopify/docker-ssh-agent-forward"
+  head "https://github.com/Shopify/docker-ssh-agent-forward.git"
+  url "https://github.com/Shopify/docker-ssh-agent-forward/archive/1.0.tar.gz"
+  sha256 "75d111b84cffbb6caed6a555cf88263a8079b609d2d0bb484afefdbb01f91251"
 
   def install
     ENV['PATH']   = "#{ENV['PATH']}:/usr/local/bin"


### PR DESCRIPTION
Based on a HackerOne report, it appears as though this does not properly authenticate the source repository. 

We have forked the repository and versioned it out.

@Shopify/appsec 