### PR TITLE
We want to use Homebrew's default bottle URL for qt@5.5

### DIFF
--- a/qt@5.5.rb
+++ b/qt@5.5.rb
@@ -9,6 +9,7 @@ class QtAT55 < Formula
   revision 1
 
   bottle do
+    root_url "https://homebrew.bintray.com/bottles"
     sha256 "30c5a19c4c18737d40ab072d27a1b5220e746eb7a549812ceb1799eb07cfd58f" => :high_sierra
     sha256 "f44403a72ab524a6f010bcf86f1414c42729f4763f4e7c2cfb0f6cba2b6135d2" => :sierra
     sha256 "e1e66c950b66c9bd59b43566a4a5919f4f14a0331c7d9aa062d8c6a152e157c4" => :el_capitan


### PR DESCRIPTION
Homebrew looks to a different directory by default for finding bottles for formulas defined in taps. For Shopify's tap, that URL is https://homebrew.bintray.com/bottles-shopify/

Since we aren't creating the bottles ourselves, and actually want the historic Homebrew ones, we need to explicitly specify the default Homebrew root.

More documentation [here](https://docs.brew.sh/Bottles) and a [Discourse question](https://discourse.brew.sh/t/default-root-url-for-custom-taps/1245) on this very topic.