### PR TITLE
Fix mountain lion qt issue

### DIFF
--- a/qt@5.5.rb
+++ b/qt@5.5.rb
@@ -23,7 +23,9 @@ class QtAT55 < Formula
   # OS X 10.7 Lion is still supported in Qt 5.5, but is no longer a reference
   # configuration and thus untested in practice. Builds on OS X 10.7 have been
   # reported to fail: <https://github.com/Homebrew/homebrew/issues/45284>.
-  depends_on :macos => :mountain_lion
+  # 10.7 Lion is no longer supported in brew. See:
+  # https://github.com/Shopify/homebrew-shopify/issues/125.
+  depends_on :macos => :mavericks
 
   # Build error: Fix library detection for QtWebEngine with Xcode 7.
   # https://codereview.qt-project.org/#/c/1w27759/


### PR DESCRIPTION
This "fixes" #125 - it at least makes the tap work. I've now idea if it works the qt@5.5 formula works.

I've tested locally with:

```bash
cd /usr/local/Homebrew/Library/Taps/
mkdir shopify
cd shopify
git clone git@github.com:shopify/homebrew-shopify
git checkout fix-mountain-lion-issue
brew tap shopify/shopify
brew install ejson
```

`ejson` is provided by the shopify/shopify tap.