### PR TITLE
remove graphicsmagick bottle as it has no png support

### DIFF
--- a/shopify-graphicsmagick.rb
+++ b/shopify-graphicsmagick.rb
@@ -9,11 +9,6 @@ class ShopifyGraphicsmagick < Formula
   sha256 "334fa009c7a1b5b91849b971ec85dffff19fb23737568cfdb49aee853731e7a5"
   revision 2
 
-  bottle do
-    root_url "https://storage.googleapis.com/shopify-dev-public"
-    sha256 "c4e248c17e8e40cc0a3b7c701d6b95ed8e3c58076c399cdd645340100410f8c2" => :high_sierra
-  end
-
   conflicts_with "graphicsmagick", :because => "shopify-graphicsmagick is newer"
 
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg


### PR DESCRIPTION
Fixing https://github.com/Shopify/homebrew-shopify/issues/109 again as https://github.com/Shopify/homebrew-shopify/pull/110 removed imagemagick's bottle

It seems like the bottled version of graphicsmagick was built without libpng being present, which means you can do things like `curl https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png | /usr/local/bin/gm identify -` which mogrify in core relies on.

`otool -L ./gm` (with the `gm` binary found in https://storage.googleapis.com/shopify-dev-public/shopify-graphicsmagick-1.4.020150705_2.high_sierra.bottle.tar.gz) produces:

```
@@HOMEBREW_CELLAR@@/shopify-graphicsmagick/1.4.020150705_2/lib/libGraphicsMagick.3.dylib (compatibility version 17.0.0, current version 17.0.0)
	@@HOMEBREW_PREFIX@@/opt/libtiff/lib/libtiff.5.dylib (compatibility version 9.0.0, current version 9.0.0)
	@@HOMEBREW_PREFIX@@/opt/freetype/lib/libfreetype.6.dylib (compatibility version 23.0.0, current version 23.0.0)
	@@HOMEBREW_PREFIX@@/opt/jpeg/lib/libjpeg.9.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.5)
	/usr/lib/libxml2.2.dylib (compatibility version 10.0.0, current version 10.9.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
```

which does not contain a reference to libpng

but if I `brew reinstall -s shopify/shopify/shopify-graphicsmagick` and then 
```
otool -L `which gm`

	/usr/local/Cellar/shopify-graphicsmagick/1.4.020150705_2/lib/libGraphicsMagick.3.dylib (compatibility version 17.0.0, current version 17.0.0)
	/usr/local/opt/webp/lib/libwebp.7.dylib (compatibility version 8.0.0, current version 8.4.0)
	/usr/local/opt/libtiff/lib/libtiff.5.dylib (compatibility version 10.0.0, current version 10.0.0)
	/usr/local/opt/freetype/lib/libfreetype.6.dylib (compatibility version 23.0.0, current version 23.1.0)
	/usr/local/opt/jpeg/lib/libjpeg.9.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 53.0.0, current version 53.0.0)
	/usr/lib/liblzma.5.dylib (compatibility version 6.0.0, current version 6.3.0)
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.5)
	/usr/lib/libxml2.2.dylib (compatibility version 10.0.0, current version 10.9.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.200.5)
```

Once this is merged (or maybe a fixed bottle is uploaded) it would be great if we could trigger a fresh install of graphicsmagick on developer's machines. Can we bump the version or something?
