### PR TITLE
Pin pyenv to version that doesn't fail on Mojave

### DIFF
--- a/pyenv@1.2.11.rb
+++ b/pyenv@1.2.11.rb
@@ -1,0 +1,41 @@
+class PyenvAT1211 < Formula
+  desc "Python version management"
+  homepage "https://github.com/pyenv/pyenv"
+  url "https://github.com/pyenv/pyenv/archive/v1.2.11.tar.gz"
+  sha256 "3756c0e386c3a6a6b36f2f8d6cc55441cc3aae1190f74c01f15d7dcdc0cae6fa"
+  version_scheme 1
+  head "https://github.com/pyenv/pyenv.git"
+
+  bottle do
+    cellar :any
+    root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
+    sha256 "14c889febc0ba01b956d34021afd2225ef2ef41ad4fdb2d29f7d2d077afdb6cc" => :mojave
+  end
+
+  depends_on "autoconf"
+  depends_on "openssl"
+  depends_on "pkg-config"
+  depends_on "readline"
+
+  conflicts_with "pyenv"
+
+  def install
+    inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX
+
+    system "src/configure"
+    system "make", "-C", "src"
+
+    prefix.install Dir["*"]
+    %w[pyenv-install pyenv-uninstall python-build].each do |cmd|
+      bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"
+    end
+
+    # Do not manually install shell completions. See:
+    #   - https://github.com/pyenv/pyenv/issues/1056#issuecomment-356818337
+    #   - https://github.com/Homebrew/homebrew-core/pull/22727
+  end
+
+  test do
+    shell_output("eval \"$(#{bin}/pyenv init -)\" && pyenv versions")
+  end
+end


### PR DESCRIPTION
To resolve https://discourse.shopify.io/t/dev-up-fails-to-install-python-no-module-named-pyexpat/3680/6, until a new release eliminates this problem.

https://discourse.shopify.io/t/dev-up-fails-to-install-python-no-module-named-pyexpat/3680/6
