### PR TITLE
update presto jdbc/cli to latest presto versions

### DIFF
--- a/presto-cli.rb
+++ b/presto-cli.rb
@@ -1,9 +1,10 @@
 class PrestoCli < Formula
   desc "Presto CLI executable to connect and run queries against Presto"
-  homepage "https://prestodb.io/docs/current/installation/cli.html"
-  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/0.151/presto-cli-0.151-executable.jar"
-  sha256 "7d8cde7a38080a08425445e200dc7ecb26635204c32769a59277133bf6328fbb"
-  version "0.151"
+  homepage "https://prestodb.io/docs/0.222/installation/cli.html"
+  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/0.222/presto-cli-0.222-executable.jar"
+  sha256 "731397ebe97413f402fb92bcd87dd9639f0844a5dfe52d6dcc69eb4c221362a5"
+  version "0.222"
+
 
   def install
     lib.install "presto-cli-#{version}-executable.jar"

--- a/presto-jdbc.rb
+++ b/presto-jdbc.rb
@@ -1,9 +1,9 @@
 class PrestoJdbc < Formula
   desc "JAR file for connecting to Presto over JDBC"
-  homepage "http://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html#connect-using-ssl"
-  url "https://s3.amazonaws.com/shopify-data-downloads/presto-jdbc-0.148-shopify.jar"
-  sha256 "5776c167ec1bfb1aa98ba99746acef49fe6ac8a2ac094104ce745181717bed20"
-  version "0.148-shopify"
+  homepage "http://prestodb.github.io/docs/0.222/installation/jdbc.html"
+  url "http://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.222/presto-jdbc-0.222.jar"
+  sha256 "621da8cab3b09535152b72fe1f4e4eebfb6906a9972723f8241b156d2c4678d9"
+  version "0.222"
 
   def install
     libexec.install "presto-jdbc-#{version}.jar"


### PR DESCRIPTION
This updates the Presto JDBC and Presto CLI versions to the latest (0.222) for brew installs.

I really don't know what this Shopify version is of 0.148 or what it's for (maybe just renamed because it was pulling from our own S3 bucket?); I can use the latest JDBC driver without issue.