### PR TITLE
symlink presto

### DIFF
--- a/presto-jdbc.rb
+++ b/presto-jdbc.rb
@@ -1,11 +1,15 @@
 class PrestoJdbc < Formula
   desc "JAR file for connecting to Presto over JDBC"
-  homepage "http://prestodb.github.io/docs/0.222/installation/jdbc.html"
-  url "http://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.222/presto-jdbc-0.222.jar"
-  sha256 "621da8cab3b09535152b72fe1f4e4eebfb6906a9972723f8241b156d2c4678d9"
-  version "0.222"
+  homepage "http://prestodb.github.io/docs/0.223/installation/jdbc.html"
+  url "http://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.223/presto-jdbc-0.223.jar"
+  sha256 "44ba89800257b085e8e0fc7dd95e58f9f767fa69f543f693b6f6f58937181aa5"
+  version "0.223"
 
   def install
     libexec.install "presto-jdbc-#{version}.jar"
+  end
+
+  def post_install
+      lib.install_symlink "#{version}/libexec/presto-jdbc-#{version}.jar" => "../../presto-jdbc-latest.jar"
   end
 end


### PR DESCRIPTION
This adds a symlink for the `presto-jdbc` driver so that when users upgrade/install the driver they can just point to latest in the root presto folder (and not expect it to move/change as long as they provide the latest link to DataGrip)