### PR TITLE
Update secret-sender formula for v2.0.0

### DIFF
--- a/secret-sender.rb
+++ b/secret-sender.rb
@@ -3,8 +3,8 @@ require 'fileutils'
 class SecretSender < Formula
   desc 'SecretSender is a little utility to securely share secrets to other users.'
   homepage 'https://github.com/Shopify/secret-sender'
-  url 'https://github.com/Shopify/secret-sender/archive/v1.0.0.tar.gz'
-  sha256 'f395b5da63d6c031b756622b6ad8430e8ca54d60d8d7266d7132b1265c4e2d39'
+  url 'https://github.com/Shopify/secret-sender/archive/v2.0.0.tar.gz'
+  sha256 '282a90308b401f99f21885a34f9b5859ee90e9863ef2e87b4f522e57c9e53be6'
 
   depends_on 'go' => :build
 


### PR DESCRIPTION
I got part way through this guide https://docs.google.com/document/d/1IYDdjrTEiDulZ9yGLlqL7bR50PBO3u2oDKngum2joXo/edit# (original is at http://notes.burke.libbey.me/bumping-private-homebrew/)

Steps 1-5 are all good for me now, but I get stuck on:

6. `brew install --build-bottle ./secret-sender.rb`
7. `brew bottle secret-sender` 💥 

💥 : This command returns
`Error: Formula not installed or up-to-date: shopify/shopify/secret-sender` i.e. https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bottle.rb#L212 for some reason ... 🤔 