### PR TITLE
Update buildkite-agent to 3.15.2

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,9 +3,9 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.14.0"
-    url     "https://github.com/buildkite/agent/releases/download/v3.14.0/buildkite-agent-darwin-amd64-3.14.0.tar.gz"
-    sha256  "25484cc4601da2008ad0cef65c4295ac0db5eea929212a35acf432f08366bd39"
+    version "3.15.2"
+    url     "https://github.com/buildkite/agent/releases/download/v3.15.2/buildkite-agent-darwin-amd64-3.15.2.tar.gz"
+    sha256  "6cb1949b106c92d33dee51da3febcb9a271a1e2ab1c55bb729c043bdea3c8502"
   end
 
   option "token=", "Your account's agent token to add to the config on install"


### PR DESCRIPTION
This updates the Shopify Homebrew `buildkite-agent` to 3.15.2, to incorporate new features.