### PR TITLE
[LuaJit] Force 10.14 as a deployment target instead of Catalina…

### DIFF
--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -37,11 +37,15 @@ class LuajitShopify < Formula
     # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
     # is not set then it's forced to 10.4, which breaks compile on Mojave.
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-
+      
     ENV.O2 # Respect the developer's choice.
 
     args = %W[PREFIX=#{prefix}]
-    args << "XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT" if build.with? "52compat"
+    cflags = []
+    cflags << "-DLUAJIT_ENABLE_LUA52COMPAT" if build.with? "52compat"
+    cflags << "-fno-stack-check" if MacOS.version == "10.15"
+
+    args << "XCFLAGS=#{cflags.join(" ")}" if cflags.present?
 
     # This doesn't yet work under superenv because it removes "-g"
     args << "CCDEBUG=-g" if build.with? "debug"


### PR DESCRIPTION
Neovim Issue for the same problem: https://github.com/neovim/neovim/issues/11192#issuecomment-540683028
XCode 11 Thread: https://forums.developer.apple.com/thread/121887

The exception could probably be worked around in a better way but I don't want to ~expose the fact I can write C code yet~ 

The failure is:
```
BUILDVM   jit/vmdef.lua
make[2]: *** [lj_folddef.h] Segmentation fault: 11
make[2]: *** Deleting file `lj_folddef.h'
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [amalg] Error 2
make: *** [amalg] Error 2
```

with this patch, it's hacky as hell, but gets us going (right now we have to be on Catalina, which means no-one can officially develop for core apps like spy)

Locally patched: 
```
~ $ brew reinstall luajit-shopify
==> Reinstalling shopify/shopify/luajit-shopify
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Preferences or
https://developer.apple.com/download/more/.

==> Downloading http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
Already downloaded: /Users/doug/Library/Caches/Homebrew/downloads/de685ee74f26d1ae7fa6a763434efa41f11e4a192ef0cd1fa1eaf39281f8c1f3--LuaJIT-2.1.0-beta3.tar.gz
==> make amalg PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 INSTALL_TNAME=luajit
==> make install PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 INSTALL_TNAME=luajit
🍺  /usr/local/Cellar/luajit-shopify/2.1.0-beta3: 36 files, 2.2MB, built in 25 seconds
```