### PR TITLE
Remove no-stack-check workaround for out of date 10.15 Command L…

### DIFF
--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -43,7 +43,6 @@ class LuajitShopify < Formula
     args = %W[PREFIX=#{prefix}]
     cflags = []
     cflags << "-DLUAJIT_ENABLE_LUA52COMPAT" if build.with? "52compat"
-    cflags << "-fno-stack-check" if MacOS.version == "10.15"
 
     args << "XCFLAGS=#{cflags.join(" ")}" if cflags.present?
 


### PR DESCRIPTION
Fixes #158 

I had an update to my local Command Line Tools before christmas and I noticed it didn't need the `-fno-stack-check` workaround for 10.15 any more as a result.

```
CLT Version: 11.3.0.0.1.1574140115
```

Workaround *works* still but I don't like disabling features of a compiler

```
==> Reinstalling shopify/shopify/luajit-shopify
==> Downloading http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
Already downloaded: /Users/doug/Library/Caches/Homebrew/downloads/de685ee74f26d1ae7fa6a763434efa41f11e4a192ef0cd1fa1eaf39281f8c1f3--LuaJIT-2.1.0-beta3.tar.gz
==> make amalg PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 XCFLAGS=-fno-stack-check INSTALL_TNAME=luajit
==> make install PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 XCFLAGS=-fno-stack-check INSTALL_TNAME=luajit
🍺  /usr/local/Cellar/luajit-shopify/2.1.0-beta3: 36 files, 2.2MB, built in 22 seconds
```

Workaround removed

```
==> Reinstalling shopify/shopify/luajit-shopify
==> Downloading http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
Already downloaded: /Users/doug/Library/Caches/Homebrew/downloads/de685ee74f26d1ae7fa6a763434efa41f11e4a192ef0cd1fa1eaf39281f8c1f3--LuaJIT-2.1.0-beta3.tar.gz
==> make amalg PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 INSTALL_TNAME=luajit
==> make install PREFIX=/usr/local/Cellar/luajit-shopify/2.1.0-beta3 INSTALL_TNAME=luajit
🍺  /usr/local/Cellar/luajit-shopify/2.1.0-beta3: 36 files, 2.2MB, built in 25 seconds
```

(You can see that the `XCFLAGS` are removed now and the compile is good.