### PR TITLE
Change presto-jdbc homepage and url to use https

### DIFF
--- a/presto-jdbc.rb
+++ b/presto-jdbc.rb
@@ -1,7 +1,7 @@
 class PrestoJdbc < Formula
   desc "JAR file for connecting to Presto over JDBC"
-  homepage "http://prestodb.github.io/docs/0.223/installation/jdbc.html"
-  url "http://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.223/presto-jdbc-0.223.jar"
+  homepage "https://prestodb.github.io/docs/0.223/installation/jdbc.html"
+  url "https://repo1.maven.org/maven2/com/facebook/presto/presto-jdbc/0.223/presto-jdbc-0.223.jar"
   sha256 "44ba89800257b085e8e0fc7dd95e58f9f767fa69f543f693b6f6f58937181aa5"
   version "0.223"
 


### PR DESCRIPTION
Currently if you try to run `brew install presto-jdbc` it fails
with a 501 HTTPS Required error. Since the Maven repo is using
HTTPS, the url should also be updated accordingly.