### PR TITLE
Add shopify-cli v0.9.1

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -1,0 +1,39 @@
+class ShopifyCli < Formula
+  version '0.9.1'
+  homepage 'https://shopify.github.io/shopify-app-cli'
+  url "https://rubygems.org/downloads/shopify-cli-#{version}.gem"
+  sha256 'b95a0956ce6f6ac25750be538cd7018ea8e4dc6cb86fdae8f149acce329b37b7'
+  desc <<~DESC
+    Shopify CLI helps you build Shopify apps faster. It quickly scaffolds Node.js
+    and Ruby on Rails embedded apps. It also automates many common tasks in the
+    development process and lets you quickly add popular features, such as billing
+    and webhooks.
+  DESC
+
+  bottle :unneeded
+
+  depends_on 'git' => '2.13'
+
+  def install
+    system 'tar', '-xzf', cached_download, '--directory', buildpath
+
+    (buildpath/'src').mkpath
+    (buildpath/'symlink').mkpath
+    system 'tar', '-xzf', buildpath/'data.tar.gz', '--directory', buildpath/'src'
+
+    prefix.install buildpath/'src'
+
+    exe = prefix/'src/bin/shopify'
+    script = buildpath/'symlink/shopify'
+
+    script_content = <<~SCRIPT
+      #!/usr/bin/env bash
+      #{RbConfig.ruby} --disable=gems -I #{prefix} #{exe} $@
+    SCRIPT
+
+    File.write(script, script_content)
+    FileUtils.chmod("+x", script)
+
+    bin.install script
+  end
+end


### PR DESCRIPTION
This adds the first version of the new Shopify CLI to the cask.