### PR TITLE
Removed 'z' from first tar command

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -15,7 +15,7 @@ class ShopifyCli < Formula
   depends_on 'git' => '2.13'
 
   def install
-    system 'tar', '-xzf', cached_download, '--directory', buildpath
+    system 'tar', '-xf', cached_download, '--directory', buildpath
 
     (buildpath/'src').mkpath
     (buildpath/'symlink').mkpath


### PR DESCRIPTION
While `tar -xzf` works on macOS even if the given file is not compressed, on Linux it will complain.

Since the `.gem` file is really an uncompressed tarball, `tar -xf` will work on both macOS and Linux as the first command of the install formula.

Note that this PR fixes [#814](https://github.com/Shopify/shopify-app-cli/issues/814) for the current release of Shopify App CLI; PR [#846](https://github.com/Shopify/shopify-app-cli/pull/846) fixes it for future releases.

🎩 Tophatted on macOS Catalina and Ubuntu 20.04