### PR TITLE
Remove version to allow automated brew update

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -1,5 +1,4 @@
 class ShopifyCli < Formula
-  version '1.4.0'
   homepage 'https://shopify.github.io/shopify-app-cli'
   url 'https://rubygems.org/downloads/shopify-cli-1.4.0.gem'
   sha256 '489a6ade9925ca0953916cec1968ff733943c05d57ce09703e698d1defba5589'


### PR DESCRIPTION
This is causing brew update to fail because the version # is being hardcoded, thus throwing error
```
Error: You need to bump this formula manually since the new version
and old version are both 1.4.0.
```