### PR TITLE
bumps Voucher client to v2.5.2

### DIFF
--- a/voucher_client.rb
+++ b/voucher_client.rb
@@ -3,7 +3,7 @@ class VoucherClient < Formula
   homepage "https://github.com/Shopify/voucher"
   url "https://github.com/Shopify/voucher/releases/download/v2.5.2/voucher_client_2.5.2_Darwin_x86_64.tar.gz"
   version "v2.5.2"
-  sha256 "e36a04e4b52d7be9888e0810a5fccbded5e5a0bbdedd03fb52a6dbb549e3f78d"
+  sha256 "f2d121409fe6d7619497be6efd68daca1aaeb0ffcd9d054b389fbdb95b5f48a8"
 
   def install
     bin.install "voucher_client"


### PR DESCRIPTION
Didn't commit my change that fixed the hash, this fixes it now.