### PR TITLE
Add autoconf 2.69 to the backported packages

### DIFF
--- a/Formula/autoconf@2.69.rb
+++ b/Formula/autoconf@2.69.rb
@@ -1,0 +1,32 @@
+class AutoconfAT269 < Formula
+  desc "Automatic configure script builder"
+  homepage "https://www.gnu.org/software/autoconf"
+  url "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
+  mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz"
+  sha256 "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969"
+  license "GPL-2.0-or-later"
+
+  uses_from_macos "m4"
+  uses_from_macos "perl"
+
+  def install
+    on_macos do
+      ENV["PERL"] = "/usr/bin/perl"
+
+      # force autoreconf to look for and use our glibtoolize
+      inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"
+      # also touch the man page so that it isn't rebuilt
+      inreplace "man/autoreconf.1", "libtoolize", "glibtoolize"
+    end
+
+    system "./configure", "--prefix=#{prefix}", "--with-lispdir=#{elisp}"
+    system "make", "install"
+
+    rm_f info/"standards.info"
+  end
+
+  test do
+    cp pkgshare/"autotest/autotest.m4", "autotest.m4"
+    system bin/"autoconf", "autotest.m4"
+  end
+end


### PR DESCRIPTION
2.70 and more importantly 2.71 cause lots of issues with ruby, so it is useful to be able to pin to 2.69.