### PR TITLE
Deprecation and style fixes

### DIFF
--- a/ejson.rb
+++ b/ejson.rb
@@ -1,29 +1,31 @@
+# typed: false
+# frozen_string_literal: true
+
 class Ejson < Formula
-  desc 'EJSON is a small library to manage encrypted secrets using asymmetric encryption.'
-  homepage 'https://github.com/Shopify/ejson'
-  url 'https://github.com/Shopify/ejson/archive/v1.2.1.tar.gz'
+  desc "Ejson is a small library to manage encrypted secrets using asymmetric encryption"
+  homepage "https://github.com/Shopify/ejson"
+  url "https://github.com/Shopify/ejson/archive/v1.2.1.tar.gz"
 
   bottle do
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    cellar :any_skip_relocation
-    sha256 "cead7026c5bf46694ce67b5b664bd7a82570d76ff479de35dbb71d43a346b2d8" => :catalina
+    sha256 cellar: :any_skip_relocation, catalina: "cead7026c5bf46694ce67b5b664bd7a82570d76ff479de35dbb71d43a346b2d8"
   end
 
-  depends_on 'go' => :build
+  depends_on "go" => :build
 
   def install
-    ENV['GEM_HOME'] = buildpath/'.gem'
-    ENV['PATH'] = "#{ENV['GEM_HOME']}/bin:#{ENV['PATH']}"
-    system('gem', 'install', 'bundler')
-    system('bundle', 'install')
-    ENV['GOPATH'] = buildpath/'.gopath'
-    system('mkdir', '-p', buildpath/'.gopath/src/github.com/Shopify')
-    system('ln', '-sf', buildpath, buildpath/'.gopath/src/github.com/Shopify/ejson')
-    system('go', 'build', '-o', 'ejson', 'github.com/Shopify/ejson/cmd/ejson')
-    system('make', 'man')
+    ENV["GEM_HOME"] = buildpath/".gem"
+    ENV["PATH"] = "#{ENV["GEM_HOME"]}/bin:#{ENV["PATH"]}"
+    system("gem", "install", "bundler")
+    system("bundle", "install")
+    ENV["GOPATH"] = buildpath/".gopath"
+    system("mkdir", "-p", buildpath/".gopath/src/github.com/Shopify")
+    system("ln", "-sf", buildpath, buildpath/".gopath/src/github.com/Shopify/ejson")
+    system("go", "build", "-o", "ejson", "github.com/Shopify/ejson/cmd/ejson")
+    system("make", "man")
 
-    bin.install 'ejson'
-    man1.install Dir[buildpath/'build/man/man1/*']
-    man5.install Dir[buildpath/'build/man/man5/*']
+    bin.install "ejson"
+    man1.install Dir[buildpath/"build/man/man1/*"]
+    man5.install Dir[buildpath/"build/man/man5/*"]
   end
 end

--- a/libzookeeper.rb
+++ b/libzookeeper.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class Libzookeeper < Formula
   desc "Centralized server for distributed coordination of services - library and headers only"
   homepage "https://zookeeper.apache.org/"
@@ -8,10 +11,9 @@ class Libzookeeper < Formula
   end
 
   bottle do
-    cellar :any
     rebuild 2
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    sha256 "d0b6bb4485c4c7870ce9864936adab5b90a015f3e3fd209fa855887e03f2fe53" => :catalina
+    sha256 cellar: :any, catalina: "d0b6bb4485c4c7870ce9864936adab5b90a015f3e3fd209fa855887e03f2fe53"
   end
 
   def install
@@ -19,12 +21,11 @@ class Libzookeeper < Formula
 
     cd "src/c" do
       system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{prefix}",
-                            "--without-cppunit"
+             "--prefix=#{prefix}",
+             "--without-cppunit"
       system "make", "install"
     end
 
     rm_rf bin
   end
-
 end

--- a/secret-sender.rb
+++ b/secret-sender.rb
@@ -1,18 +1,18 @@
-require 'fileutils'
+# typed: false
+# frozen_string_literal: true
+
+require "fileutils"
 
 class SecretSender < Formula
-  desc 'SecretSender is a little utility to securely share secrets to other users.'
-  homepage 'https://github.com/Shopify/secret-sender'
-  url 'https://github.com/Shopify/secret-sender/archive/v2.0.0.tar.gz'
-  sha256 '282a90308b401f99f21885a34f9b5859ee90e9863ef2e87b4f522e57c9e53be6'
-
-  depends_on 'go' => :build
+  desc "SecretSender is a little utility to securely share secrets to other users"
+  homepage "https://github.com/Shopify/secret-sender"
+  url "https://github.com/Shopify/secret-sender/archive/v2.0.0.tar.gz"
+  sha256 "282a90308b401f99f21885a34f9b5859ee90e9863ef2e87b4f522e57c9e53be6"
 
   bottle do
     root_url "https://github.com/Shopify/secret-sender/releases/download/v2.0.0"
-    cellar :any_skip_relocation
     rebuild 1
-    sha256 "54e2bd8d55fefdb813168c300e79751353eddde775671471980966960b58d342" => :mojave
+    sha256 cellar: :any_skip_relocation, mojave: "54e2bd8d55fefdb813168c300e79751353eddde775671471980966960b58d342"
   end
 
   bottle do
@@ -22,12 +22,14 @@ class SecretSender < Formula
     sha256 "79ac412956c31da9a3c70c7d78de249d16b9375bd5f0034d7d58c5a881c0b222" => :catalina
   end
 
+  depends_on "go" => :build
+
   def install
-    FileUtils.mkdir_p('src/github.com/Shopify')
-    FileUtils.ln_sf(Dir.pwd, 'src/github.com/Shopify/secret-sender')
-    ENV['GOPATH'] = Dir.pwd
-    system('go', 'build', '-o', 'secret-sender', 'github.com/Shopify/secret-sender')
-    bin.install('secret-sender')
-    man1.install('secret-sender.1')
+    FileUtils.mkdir_p("src/github.com/Shopify")
+    FileUtils.ln_sf(Dir.pwd, "src/github.com/Shopify/secret-sender")
+    ENV["GOPATH"] = Dir.pwd
+    system("go", "build", "-o", "secret-sender", "github.com/Shopify/secret-sender")
+    bin.install("secret-sender")
+    man1.install("secret-sender.1")
   end
 end


### PR DESCRIPTION
Seeing lots of warnings (pasted below) so ran the suggested `brew style
--fix` command the the affected formulas. The main update is how the
deprecated cellar call is removed in favour of passing it to `sha256`.
Otherwise it mainly just updated single quotes to double quotes.

    Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/ejson.rb:8

    Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/ejson.rb:9

    Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/libzookeeper.rb:11

    Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/libzookeeper.rb:14

    Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/secret-sender.rb:13

    Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/secret-sender.rb:15

    Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/secret-sender.rb:19

    Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
    Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
    /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/secret-sender.rb:22