### PR TITLE
Fix fetch definition

### DIFF
--- a/theme-check.rb
+++ b/theme-check.rb
@@ -13,7 +13,7 @@ class ThemeCheck < Formula
   class RubyGemsDownloadStrategy < AbstractDownloadStrategy
     include RubyBin
 
-    def fetch
+    def fetch(timeout: nil, **options)
       ohai("Fetching theme-check from gem source")
       cache.cd do
         ENV['GEM_SPEC_CACHE'] = "#{cache}/gem_spec_cache"


### PR DESCRIPTION
This fixes the definition of the `fetch` function in the `theme-check` formula, which seems to be causing issues for people first tapping the homebrew repo.

I've tested that brew can validate the formula with this change, but I didn't add any special handling of the options as the error message suggests:

```
Calling `def fetch` in a subclass of `#<Class:0x00007fbf571fef78>::ThemeCheck::RubyGemsDownloadStrategy` is disabled! Use `def fetch(timeout: nil, **options)` and output a warning when `options` contains new unhandled options instead.
```