### PR TITLE
Deprecation fixes

### DIFF
--- a/bazel@10.rb
+++ b/bazel@10.rb
@@ -5,9 +5,8 @@ class BazelAT10 < Formula
   sha256 "708248f6d92f2f4d6342006c520f22dffa2f8adb0a9dc06a058e3effe7fee667"
 
   bottle do
-    cellar :any_skip_relocation
     root_url "https://s3.amazonaws.com/burkelibbey"
-    sha256 "d7b4922e6975445039caa632c3bc1490cfad8561a7b16dc26b0d875aac168323" => :high_sierra
+    sha256 cellar: :any_skip_relocation, high_sierra: "d7b4922e6975445039caa632c3bc1490cfad8561a7b16dc26b0d875aac168323"
   end
 
   bottle do

--- a/cmake30.rb
+++ b/cmake30.rb
@@ -25,10 +25,9 @@ class Cmake30 < Formula
   sha256 "6b4ea61eadbbd9bec0ccb383c29d1f4496eacc121ef7acf37c7a24777805693e"
 
   bottle do
-    cellar :any
-    sha256 "71b46be0b22a43368e8beddeb50c758d281684597bfb578c0e883151c968869f" => :yosemite
-    sha256 "5cbd2d245b6bb71480ac15d901d2caa8558f4429d2535fbef662e53431679cb2" => :mavericks
-    sha256 "21a42c38e5b78dac6598d3eedf7b26e1c856410614384ca747e277428254a4a8" => :mountain_lion
+    sha256 cellar: :any, yosemite: "71b46be0b22a43368e8beddeb50c758d281684597bfb578c0e883151c968869f"
+    sha256 cellar: :any, mavericks: "5cbd2d245b6bb71480ac15d901d2caa8558f4429d2535fbef662e53431679cb2"
+    sha256 cellar: :any, mountain_lion: "21a42c38e5b78dac6598d3eedf7b26e1c856410614384ca747e277428254a4a8"
   end
 
   option "without-docs", "Don't build man pages"

--- a/ejson.rb
+++ b/ejson.rb
@@ -5,8 +5,7 @@ class Ejson < Formula
 
   bottle do
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    cellar :any_skip_relocation
-    sha256 "cead7026c5bf46694ce67b5b664bd7a82570d76ff479de35dbb71d43a346b2d8" => :catalina
+    sha256 cellar: :any_skip_relocation, catalina: "cead7026c5bf46694ce67b5b664bd7a82570d76ff479de35dbb71d43a346b2d8"
   end
 
   depends_on 'go' => :build

--- a/ejson2env.rb
+++ b/ejson2env.rb
@@ -5,10 +5,9 @@ class Ejson2env < Formula
   sha256 'b6fdae0b9e8f5f74124ecf3c25dee8c36dfaac0ac6b85d82250761e5ebd58de2'
 
   bottle do
-    cellar :any_skip_relocation
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    sha256 "e55edfb055c4c6b7258f18f9d1677e9d545902009b0d9f8b43f60bbef02def73" => :catalina
-    sha256 "c65f899fd64aaa487e945da0e80e8bc17611ed8c1bd4d56a7067fc3824de4912" => :big_sur
+    sha256 cellar: :any_skip_relocation, catalina: "e55edfb055c4c6b7258f18f9d1677e9d545902009b0d9f8b43f60bbef02def73"
+    sha256 cellar: :any_skip_relocation, big_sur: "c65f899fd64aaa487e945da0e80e8bc17611ed8c1bd4d56a7067fc3824de4912"
   end
 
   depends_on 'go' => :build

--- a/libgda.rb
+++ b/libgda.rb
@@ -6,9 +6,9 @@ class Libgda < Formula
   revision 2
 
   bottle do
-    sha256 "e165830cedc3a0955989746145b310cc03fe96b84f18b33c4c3f2b827bdd473c" => :sierra
-    sha256 "7809bb97ebcd233a740c1e5b5cb0f291a902639a6479d5e53fdcfedd928b6582" => :el_capitan
-    sha256 "01e46f8673fcf3fad0bccdd70e9bd6fac08f0f5b7035e85318a3add4db329a9b" => :yosemite
+    sha256 sierra: "e165830cedc3a0955989746145b310cc03fe96b84f18b33c4c3f2b827bdd473c"
+    sha256 el_capitan: "7809bb97ebcd233a740c1e5b5cb0f291a902639a6479d5e53fdcfedd928b6582"
+    sha256 yosemite: "01e46f8673fcf3fad0bccdd70e9bd6fac08f0f5b7035e85318a3add4db329a9b"
   end
 
   bottle do

--- a/libzookeeper.rb
+++ b/libzookeeper.rb
@@ -8,10 +8,9 @@ class Libzookeeper < Formula
   end
 
   bottle do
-    cellar :any
     rebuild 2
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    sha256 "d0b6bb4485c4c7870ce9864936adab5b90a015f3e3fd209fa855887e03f2fe53" => :catalina
+    sha256 cellar: :any, catalina: "d0b6bb4485c4c7870ce9864936adab5b90a015f3e3fd209fa855887e03f2fe53"
   end
 
   def install

--- a/luajit-shopify.rb
+++ b/luajit-shopify.rb
@@ -13,8 +13,7 @@ class LuajitShopify < Formula
 
   bottle do
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    cellar :any
-    sha256 "0d8d72fb092e26c30bc0519626044b8d49bdc1e1a2301eab58ccbe0796233ec2" => :catalina
+    sha256 cellar: :any, catalina: "0d8d72fb092e26c30bc0519626044b8d49bdc1e1a2301eab58ccbe0796233ec2"
   end
 
   conflicts_with "luajit", :because => "shopify uses luajit 2.1. `brew uninstall luajit` first"

--- a/openssl.rb
+++ b/openssl.rb
@@ -10,10 +10,10 @@ class Openssl < Formula
   sha256 "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
 
   bottle do
-    sha256 "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810" => :catalina
-    sha256 "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6" => :mojave
-    sha256 "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132" => :high_sierra
-    sha256 "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927" => :sierra
+    sha256 catalina: "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810"
+    sha256 mojave: "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6"
+    sha256 high_sierra: "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132"
+    sha256 sierra: "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927"
   end
 
   bottle do

--- a/openssl@1.0.rb
+++ b/openssl@1.0.rb
@@ -10,10 +10,10 @@ class OpensslAT10 < Formula
   sha256 "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
 
   bottle do
-    sha256 "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810" => :catalina
-    sha256 "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6" => :mojave
-    sha256 "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132" => :high_sierra
-    sha256 "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927" => :sierra
+    sha256 catalina: "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810"
+    sha256 mojave: "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6"
+    sha256 high_sierra: "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132"
+    sha256 sierra: "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927"
   end
 
   bottle do

--- a/pyenv@1.2.11.rb
+++ b/pyenv@1.2.11.rb
@@ -7,10 +7,9 @@ class PyenvAT1211 < Formula
   head "https://github.com/pyenv/pyenv.git"
 
   bottle do
-    cellar :any
     rebuild 1
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    sha256 "28f6c6c76c6a7cef12d0fc27c7bd19f5e8672ab30aa6946935ce00b3e2ddcf0a" => :catalina
+    sha256 cellar: :any, catalina: "28f6c6c76c6a7cef12d0fc27c7bd19f5e8672ab30aa6946935ce00b3e2ddcf0a"
   end
 
   bottle do

--- a/qt@5.5.rb
+++ b/qt@5.5.rb
@@ -10,10 +10,10 @@ class QtAT55 < Formula
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"
-    sha256 "30c5a19c4c18737d40ab072d27a1b5220e746eb7a549812ceb1799eb07cfd58f" => :high_sierra
-    sha256 "f44403a72ab524a6f010bcf86f1414c42729f4763f4e7c2cfb0f6cba2b6135d2" => :sierra
-    sha256 "e1e66c950b66c9bd59b43566a4a5919f4f14a0331c7d9aa062d8c6a152e157c4" => :el_capitan
-    sha256 "debdc797d8314548a7cfc05ac97699d98ceeaf46265180a979bbb96190024d1c" => :yosemite
+    sha256 high_sierra: "30c5a19c4c18737d40ab072d27a1b5220e746eb7a549812ceb1799eb07cfd58f"
+    sha256 sierra: "f44403a72ab524a6f010bcf86f1414c42729f4763f4e7c2cfb0f6cba2b6135d2"
+    sha256 el_capitan: "e1e66c950b66c9bd59b43566a4a5919f4f14a0331c7d9aa062d8c6a152e157c4"
+    sha256 yosemite: "debdc797d8314548a7cfc05ac97699d98ceeaf46265180a979bbb96190024d1c"
   end
 
   keg_only :versioned_formula

--- a/secret-sender.rb
+++ b/secret-sender.rb
@@ -10,16 +10,14 @@ class SecretSender < Formula
 
   bottle do
     root_url "https://github.com/Shopify/secret-sender/releases/download/v2.0.0"
-    cellar :any_skip_relocation
     rebuild 1
-    sha256 "54e2bd8d55fefdb813168c300e79751353eddde775671471980966960b58d342" => :mojave
+    sha256 cellar: :any_skip_relocation, mojave: "54e2bd8d55fefdb813168c300e79751353eddde775671471980966960b58d342"
   end
 
   bottle do
-    cellar :any_skip_relocation
-    rebuild 2
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
-    sha256 "79ac412956c31da9a3c70c7d78de249d16b9375bd5f0034d7d58c5a881c0b222" => :catalina
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, catalina: "79ac412956c31da9a3c70c7d78de249d16b9375bd5f0034d7d58c5a881c0b222"
   end
 
   def install

--- a/shopify-libgraphqlparser.rb
+++ b/shopify-libgraphqlparser.rb
@@ -7,10 +7,9 @@ class ShopifyLibgraphqlparser < Formula
   sha256 "2ed66fd38b6e8a4a39c646fe713b5893d3d6b076dcd34be28a356cb3cb879595"
 
   bottle do
-    cellar :any
-    sha256 "52afe0dcec93ec9b886c3d7ecacf64c81f3887e299d3238aff7b4fd295a24329" => :el_capitan
-    sha256 "4fed85aba87c4cb54168cb1e8c73d6e7d4eee9689b09f18c07137ffdfb850ac3" => :yosemite
-    sha256 "1dfc83c494e8ceef8eb5d757190312d13ecafeb1b88464c44073417989bf5488" => :mavericks
+    sha256 cellar: :any, el_capitan: "52afe0dcec93ec9b886c3d7ecacf64c81f3887e299d3238aff7b4fd295a24329"
+    sha256 cellar: :any, yosemite: "4fed85aba87c4cb54168cb1e8c73d6e7d4eee9689b09f18c07137ffdfb850ac3"
+    sha256 cellar: :any, mavericks: "1dfc83c494e8ceef8eb5d757190312d13ecafeb1b88464c44073417989bf5488"
   end
 
   bottle do

--- a/shopify-ruby.rb
+++ b/shopify-ruby.rb
@@ -18,7 +18,7 @@ class ShopifyRuby < Formula
   bottle do
     root_url "https://s3.amazonaws.com/burkelibbey"
     rebuild 2
-    sha256 "78dbba5c1744c944cef438678c1d1371536fc10654735b630d8621863501806c" => :sierra
+    sha256 sierra: "78dbba5c1744c944cef438678c1d1371536fc10654735b630d8621863501806c"
   end
 
   bottle do

--- a/yarn.rb
+++ b/yarn.rb
@@ -9,8 +9,7 @@ class Yarn < Formula
 
   bottle do
     root_url "https://burkelibbey.s3.amazonaws.com"
-    cellar :any_skip_relocation
-    sha256 "b43c66a5cc378712dc9871bcc31abb78ad1f9790a9b1226109bc1c2f98d1e626" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "b43c66a5cc378712dc9871bcc31abb78ad1f9790a9b1226109bc1c2f98d1e626"
   end
 
   bottle do


### PR DESCRIPTION
Fixes deprecation errors as exampled below with
`brew style --fix --only-cops FormulaAudit/BottleFormat *.rb`

        Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `>
        Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix >
        /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/ejson.rb:8

        Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update t>
        Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix >
        /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/ejson.rb:9