### PR TITLE
Update nginx-shopify to not depend on deprecated Homebrew features

### DIFF
--- a/nginx-shopify.rb
+++ b/nginx-shopify.rb
@@ -46,7 +46,6 @@ class NginxShopify < Formula
     sha256 "42f0384f80b6a9b4f42f91ee688baf69165d0573347e6ea84ebed95e928211d7"
   end
 
-  env :userpaths
   skip_clean "logs"
 
   def install
@@ -85,7 +84,7 @@ class NginxShopify < Formula
       args << "--add-module=#{HOMEBREW_PREFIX}/share/#{m}"
     end
 
-    luajit_path = `brew --prefix luajit-shopify`.chomp
+    luajit_path = `#{HOMEBREW_PREFIX}/bin/brew --prefix luajit-shopify`.chomp
     ENV["LUAJIT_LIB"] = "#{luajit_path}/lib"
     ENV["LUAJIT_INC"] = "#{luajit_path}/include/luajit-2.1"
 


### PR DESCRIPTION
It would appear that newer versions of Homebrew have removed the `userpaths` functionality, as inferred via https://github.com/denji/homebrew-nginx/issues/383 and myself running into an error upon trying to install this recipe as-is

That user path seems to have only been used to inherit the `$PATH` such that a subsequent later call to `brew` would succeed.

So; 

 * Remove the call to the deprecated `env :userpaths`
 * Update the call to `brew` to use a full path based on the exposed constant of `HOMEBREW_PREFIX` which we depend on elsewhere in this formula.


I've 🎩  this locally, with some assistance from @spike01 and we believe that this will be necessary for any future new starters to be able to get `nginx-shopify` rolling on their newly issued Macs.