### PR TITLE
use plist_name DSL for oauth_tunnel_client label

### DIFF
--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -4,7 +4,7 @@ class OauthTunnelClient < Formula
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
   url 'https://storage.googleapis.com/binaries.shopifykloud.com/oauth-tunnel/oauth-tunnel-client-cb1489c167049627ed5b96b903948af80b482191.tar.gz'
   sha256 '1edfc34429674e739f843f99f2c960306f154fcd3dfac66f9b2e9c676fd419a4'
-  version "0.3.3"
+  version "0.3.4"
 
   def install
     bin.install({'oauth-tunnel-client_darwin_amd64' => 'oauth-tunnel-client'})
@@ -25,7 +25,7 @@ class OauthTunnelClient < Formula
        <string>release</string>
       </dict>
       <key>Label</key>
-      <string>com.shopify.oauth-tunnel-client</string>
+      <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
         <string>/usr/local/bin/oauth-tunnel-client</string>


### PR DESCRIPTION
Bump the version and let brew set the `plist_name` based on the DSL Macro.  I think brew used to force it, but it doesn't anymore and it causing the following error on updated systems:

```
$ brew services start oauth-tunnel-client
Bootstrap failed: 5: Input/output error
Error: Failure while executing; `/bin/launchctl bootstrap gui/501 /Users/mbruce/Library/LaunchAgents/homebrew.mxcl.oauth-tunnel-client.plist` exited with 5.
```
because the Label doesn't match:
```
mbruce@Matthews-MacBook-Pro-2 starscream (mb-update-hive-targets-global) $ cat /Users/mbruce/Library/LaunchAgents/homebrew.mxcl.oauth-tunnel-client.plist
<?xml version="1.0" encoding="UTF-8"?>
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>EnvironmentVariables</key>
  <dict>
   <key>GIN_MODE</key>
   <string>release</string>
  </dict>
  <key>Label</key>
  <string>com.shopify.oauth-tunnel-client</string>
  ```
  That label should be: 
  ```
  <string>homebrew.mxcl.oauth-tunnel-client</string>
  ```
  
  See also: 
  https://docs.brew.sh/Formula-Cookbook#launchd-plist-files