### PR TITLE
Upgrade libzookeeper to use zookeeper 3.7.0

### DIFF
--- a/libzookeeper.rb
+++ b/libzookeeper.rb
@@ -11,6 +11,7 @@ class Libzookeeper < Formula
   bottle do
     root_url "https://github.com/Shopify/homebrew-shopify/releases/download/bag-of-holding"
     sha256 cellar: :any, big_sur: "291ff13634c99bb305c4b88c976fb1ff4ca28dc66f9f8537a0dd35bbf64721c1"
+    sha256 cellar: :any, arm64_big_sur: "6eab138516aab0293618ccdc9333daab7c949f7c318a256fc8742cfe8e8f7983"
     sha256 cellar: :any, arm64_monterey: "698d0b4cf2320364f57f4ca1c2cbc2b0b17a61fa172cdd613a6a6fa414170728"
   end
 


### PR DESCRIPTION
This is mainly to upgrade libzookeeper to work on apple silicon CPUs. Currently building the latest zookeeper from source works, but libzookeeper doesn't. Diffing what the current formula is for zookeeper, and following the C client README, I was able to make this work.

I'm not very familiar with compiling C programs myself so let me know if there's something I'm not doing right.

https://github.com/Homebrew/homebrew-core/blob/aa6c1b2865f90a83d7edd1c781a49cfb6a5acfe3/Formula/zookeeper.rb

https://github.com/apache/zookeeper/blob/06467dc8c20e6c7357c19904f6214bb406262ba2/zookeeper-client/zookeeper-client-c/README#L41

TODO
- [x] Try this on an intel CPU