### PR TITLE
Fix shopify-cli formula name

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -6,7 +6,7 @@
 require "formula"
 require "fileutils"
 
-class ShopifyCLI < Formula
+class ShopifyCli < Formula
   module RubyBin
     def ruby_bin
       Formula["ruby"].opt_bin


### PR DESCRIPTION
In a recent refactor, we changed the name of the formula, and that's causing the installation of the formula to fail