### PR TITLE
Bump `trino-cli` and `trino-jdbc` to 362

### DIFF
--- a/trino-cli.rb
+++ b/trino-cli.rb
@@ -1,9 +1,9 @@
 class TrinoCli < Formula
   desc "Trino CLI executable to connect and run queries against Trino"
   homepage "https://trino.io/docs/current/installation/cli.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-cli/359/trino-cli-359-executable.jar"
-  sha256 "ee6b44147dcdef3c23fff6b043f5a175e93e8d403dc90372ebaf59f856c1bd49"
-  version "359"
+  url "https://repo1.maven.org/maven2/io/trino/trino-cli/362/trino-cli-362-executable.jar"
+  sha256 "3fe3ec6d003aaceeb2b0c2701b02409c2254a7321fd49ceb8c6d123a5e444ba4"
+  version "362"
 
   def install
     bin.install "trino-cli-#{version}-executable.jar" => "trino"

--- a/trino-jdbc.rb
+++ b/trino-jdbc.rb
@@ -1,9 +1,9 @@
 class TrinoJdbc < Formula
   desc "JAR file for connecting to Trino over JDBC"
   homepage "https://trino.io/docs/current/installation/jdbc.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/359/trino-jdbc-359.jar"
-  sha256 "4ec6a83ccf9cdcab60aed0eca644f9a8a8cec256d0a2fc9e00a298be6d054098"
-  version "359"
+  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/362/trino-jdbc-362.jar"
+  sha256 "740525691b46dfe389fc597e13007b81a77f3911dc88154d8dec397aa2b1e86d"
+  version "362"
 
   def install
     libexec.install "trino-jdbc-#{version}.jar"


### PR DESCRIPTION
Bump `trino-cli` and `trino-jdbc` to 362.

Tested locally with
```
➜ brew install --build-from-source ./trino-cli.rb
trino-cli 359 is already installed but outdated
==> Downloading https://repo1.maven.org/maven2/io/trino/trino-cli/362/trino-cli-362-executable.jar
######################################################################## 100.0%
==> Upgrading trino-cli
  359 -> 362
🍺  /usr/local/Cellar/trino-cli/362: 3 files, 9.7MB, built in 4 seconds
Removing: /usr/local/Cellar/trino-cli/359... (3 files, 9.7MB)
```

```
➜ trino --version
Trino CLI 362
```