### PR TITLE
Bump toxiproxy to v2.2.0

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -3,7 +3,7 @@
 # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 
 class Toxiproxy < Formula
-  app_version = "2.1.7"
+  app_version = "2.2.0"
   homepage "https://github.com/Shopify/toxiproxy"
   license "MIT"
   version app_version
@@ -11,16 +11,16 @@ class Toxiproxy < Formula
   case
   when OS.mac? && Hardware::CPU.intel?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-darwin-amd64"
-    sha256 "cb348eeefcb7a0b6cabbdb1ef00d9fb9f3b3002c2a13e1dc327c76a9fef4976f"
+    sha256 "2b3621f98c1ead3ac9b4c938246c939c05f7711c7b7c728228001e75a9988dbb"
   when OS.mac? && Hardware::CPU.arm?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-darwin-arm64"
-    sha256 "f4d2fa3f3677fe78fcfbada6581eefc79eb1d76a10270a3c605bd29b7b7a16b1"
+    sha256 "8eb1c501762eda33b884a9acefdd8813a25c5d5c6bdcfde65fc21c34e80aa4b6"
   when OS.linux? && Hardware::CPU.intel?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-linux-amd64"
-    sha256 "dedb052f2e367dfb7597375a7077acfe72d4ef541e025b37bad43051c9f6de35"
+    sha256 "18bbc72c3f5296a27b70a725f21bdc1d5afc5659f763f488dbb401c9b0141a3b"
   when OS.linux? && Hardware::CPU.arm?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-linux-arm64"
-    sha256 "0f62adfa40b1b160b22891bc255e16935c25ff29d056d6213b35ec4e72ccb6a5"
+    sha256 "37ae1674ce5249444ef7e3ff594115c8b1f7c4c3da58e24445458a319aec656c"
   else
     odie "Unexpected platform!"
   end
@@ -29,10 +29,10 @@ class Toxiproxy < Formula
     case
     when OS.mac? && Hardware::CPU.intel?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-darwin-amd64"
-      sha256 "0519980f33f2ab242148b44a093d547a536c9b0aacc9d19b84470db33b528267"
+      sha256 "a5893ae60480925940a3900ad10153b7c734c99b621ec503e738f751f8a559c6"
     when OS.mac? && Hardware::CPU.arm?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-darwin-arm64"
-      sha256 "5878060d77e2332047fcb8a494ca6dafbb1791c73d34dd11f9d2e05b1bb7c54a"
+      sha256 "b17afe8b166b0fffeaabf699bafbbc833ca712beef80c4b346a3f8bf1c9e52f9"
     when OS.linux? && Hardware::CPU.intel?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-linux-amd64"
       sha256 "805e03f589aad0e3637b2cf973ef9d3cf73cc1fd55473c696d95569f9368eab6"


### PR DESCRIPTION
Bump toxiproxy version.

Changes: https://github.com/Shopify/toxiproxy/releases/tag/v2.2.0