### PR TITLE
Updated buildkite-agent to the latest version

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,13 +3,14 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.15.2"
-    url     "https://github.com/buildkite/agent/releases/download/v3.15.2/buildkite-agent-darwin-amd64-3.15.2.tar.gz"
-    sha256  "6cb1949b106c92d33dee51da3febcb9a271a1e2ab1c55bb729c043bdea3c8502"
-  end
-
-  def default_agent_token
-    "xxx"
+    version "3.33.3"
+    if Hardware::CPU.arm?
+      url     "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-arm64-3.33.3.tar.gz"
+      sha256  "1f7ad047f264750fb4b98e9cb7a439a768496358b544641da904913800d035c8"
+    else
+      url     "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-amd64-3.33.3.tar.gz"
+      sha256  "19f108798308a98dcdddb750faea1f8fa8dc832501fa46757ca4b462b9eb58a0"
+    end
   end
 
   def agent_etc
@@ -72,9 +73,8 @@ class BuildkiteAgent < Formula
     bin.install "buildkite-agent"
   end
 
-  def default_config_file(agent_token = default_agent_token)
+  def default_config_file
     File.read("buildkite-agent.cfg")
-        .gsub(/token=.+/, "token=\"#{agent_token}\"")
         .gsub(/bootstrap-script=.+/, "bootstrap-script=\"#{agent_bootstrap_path}\"")
         .gsub(/build-path=.+/, "build-path=\"#{agent_builds_path}\"")
         .gsub(/hooks-path=.+/, "hooks-path=\"#{agent_hooks_path}\"")
@@ -83,26 +83,21 @@ class BuildkiteAgent < Formula
 
   def caveats
     <<~EOS
-      \033[32mbuildkite-agent is now installed!\033[0m#{agent_token_reminder}
-
-      Configuration file (to configure agent meta-data, priority, name, etc):
+      \033[32mbuildkite-agent is now installed!\033[0m
+      \033[31mDon't forget to update your configuration file with your agent token\033[0m
+      Configuration file (to configure agent token, meta-data, priority, name, etc):
           #{agent_config_path}
-
       Hooks directory (for customising the agent):
           #{agent_hooks_path}
-
       Builds directory:
           #{agent_builds_path}
-
       Log paths:
           #{var}/log/buildkite-agent.log
           #{var}/log/buildkite-agent.error.log
-
       If you set up the LaunchAgent, set your machine to auto-login as
       your current user. It's also recommended to install Caffeine
       (http://lightheadsw.com/caffeine/) to prevent your machine from going to
       sleep or logging out.
-
       To run multiple agents simply run the buildkite-agent start command
       multiple times, or duplicate the LaunchAgent plist to create another
       that starts on login.
@@ -119,10 +114,8 @@ class BuildkiteAgent < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}/bin</string>
-
         <key>ProgramArguments</key>
         <array>
           <string>#{HOMEBREW_PREFIX}/bin/buildkite-agent</string>
@@ -131,44 +124,29 @@ class BuildkiteAgent < Formula
           <string>#{agent_config_path}</string>
           <!--<string>--debug</string>-->
         </array>
-
         <key>EnvironmentVariables</key>
         <dict>
           <key>PATH</key>
           <string>#{HOMEBREW_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         </dict>
-
         <key>RunAtLoad</key>
         <true/>
-
         <key>KeepAlive</key>
         <dict>
           <key>SuccessfulExit</key>
           <false/>
         </dict>
-
         <key>ProcessType</key>
         <string>Interactive</string>
-
         <key>ThrottleInterval</key>
         <integer>30</integer>
-
         <key>StandardOutPath</key>
         <string>#{var}/log/buildkite-agent.log</string>
-
         <key>StandardErrorPath</key>
         <string>#{var}/log/buildkite-agent.log</string>
       </dict>
       </plist>
     EOS
-  end
-
-  def agent_token_reminder
-    return "" unless agent_config_path.exist?
-
-    if agent_config_path.read.include?(default_agent_token)
-      "\n      \n      \033[31mDon't forget to update your configuration file with your agent token\033[0m"
-    end
   end
 
   test do


### PR DESCRIPTION
Closes: https://github.com/Shopify/mac-infra/issues/457

It's used by mac CI infrastructure and has not been updated in a while. 
