### PR TITLE
Remove deprecated bottle :unneeded

### DIFF
--- a/echo-nginx-module.rb
+++ b/echo-nginx-module.rb
@@ -4,7 +4,6 @@ class EchoNginxModule < Formula
   url "https://github.com/openresty/echo-nginx-module/archive/v0.61.tar.gz"
   version "v0.61"
   sha256 "2e6a03032555f5da1bdff2ae96c96486f447da3da37c117e0f964ae0753d22aa"
-  bottle :unneeded
 
   depends_on "lua-nginx-module"
 

--- a/lua-nginx-internals-nginx-module.rb
+++ b/lua-nginx-internals-nginx-module.rb
@@ -3,8 +3,6 @@ class LuaNginxInternalsNginxModule < Formula
   homepage "https://github.com/openresty/lua-upstream-nginx-module"
   head "https://github.com/shopify/lua-nginx-internals-nginx-module.git"
 
-  bottle :unneeded
-
   depends_on "lua-nginx-module"
 
   def install

--- a/lua-nginx-module.rb
+++ b/lua-nginx-module.rb
@@ -5,8 +5,6 @@ class LuaNginxModule < Formula
   sha256 "7d5f3439c8df56046d0564b5857fd8a30296ab1bd6df0f048aed7afb56a0a4c2"
   head "https://github.com/openresty/lua-nginx-module.git"
 
-  bottle :unneeded
-
   depends_on "luajit-shopify"
   depends_on "ngx-devel-kit"
 

--- a/lua-upstream-nginx-module.rb
+++ b/lua-upstream-nginx-module.rb
@@ -5,8 +5,6 @@ class LuaUpstreamNginxModule < Formula
   sha256 "2a69815e4ae01aa8b170941a8e1a10b6f6a9aab699dee485d58f021dd933829a"
   head "https://github.com/openresty/lua-upstream-nginx-module.git"
 
-  bottle :unneeded
-
   depends_on "lua-nginx-module"
 
   def install

--- a/ngx-devel-kit.rb
+++ b/ngx-devel-kit.rb
@@ -5,8 +5,6 @@ class NgxDevelKit < Formula
   sha256 "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
   head "https://github.com/simpl/ngx_devel_kit.git"
 
-  bottle :unneeded
-
   def install
     (share+"ngx-devel-kit").install Dir["*"]
   end


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/lua-nginx-module.rb:8
```