### PR TITLE
Update buildkite agent to 3.33.3 for ARM machines

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,9 +3,15 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.15.2"
-    url     "https://github.com/buildkite/agent/releases/download/v3.15.2/buildkite-agent-darwin-amd64-3.15.2.tar.gz"
-    sha256  "6cb1949b106c92d33dee51da3febcb9a271a1e2ab1c55bb729c043bdea3c8502"
+    if Hardware::CPU.arm?
+      version "3.33.3"
+      url     "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-arm64-3.33.3.tar.gz"
+      sha256  "1f7ad047f264750fb4b98e9cb7a439a768496358b544641da904913800d035c8" 
+    else
+      version "3.15.2"
+      url     "https://github.com/buildkite/agent/releases/download/v3.15.2/buildkite-agent-darwin-amd64-3.15.2.tar.gz"
+      sha256  "6cb1949b106c92d33dee51da3febcb9a271a1e2ab1c55bb729c043bdea3c8502"
+    end
   end
 
   def default_agent_token


### PR DESCRIPTION
Issue: https://github.com/Shopify/mac-infra/issues/457

The current version that we install for the buildkite-agent i.e. `v3.15.2` does not support M1 (ARM) machines. To add support for ARM machines, the buildkite agent is updated to v3.33.3 for **M1 (ARM) machines** only. The default still remains as v3.15.2 for other machines i.e Intel machines. It is better to look at upgrading the buildkite-agent for the Intel machines in a seperate PR as that might introduce some breaking changes to the current fleet of Intel Mac Mini Hosts.

This change is copied from https://github.com/buildkite/homebrew-buildkite/blob/master/buildkite-agent.rb