### PR TITLE
Updating oauth tunnel client for the m1

### DIFF
--- a/oauth-tunnel-client-m1.rb
+++ b/oauth-tunnel-client-m1.rb
@@ -8,9 +8,9 @@ class OauthTunnelClientM1 < Formula
 
   def install
     bin.install({'oauth-tunnel-client_darwin_arm64' => 'oauth-tunnel-client'})
-    mkdir_p('/usr/local/var/log/oauth-tunnel-client/')
-    chown(ENV['USER'], 'staff', '/usr/local/var/log/oauth-tunnel-client/')
-    chmod(0750, '/usr/local/var/log/oauth-tunnel-client/', :verbose => true)
+    mkdir_p('/opt/homebrew/var/log/oauth-tunnel-client/')
+    chown(ENV['USER'], 'admin', '/opt/homebrew/var/log/oauth-tunnel-client/')
+    chmod(0750, '/opt/homebrew/var/log/oauth-tunnel-client/', :verbose => true)
   end
   def plist
     home = Dir.home
@@ -28,14 +28,14 @@ class OauthTunnelClientM1 < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>/usr/local/bin/oauth-tunnel-client</string>
+        <string>/opt/homebrew/bin/oauth-tunnel-client</string>
       </array>
       <key>RunAtLoad</key>
       <true/>
       <key>StandardErrorPath</key>
-      <string>/usr/local/var/log/oauth-tunnel-client/oauth-tunnel-client_err.log</string>
+      <string>/opt/homebrew/var/log/oauth-tunnel-client/oauth-tunnel-client_err.log</string>
       <key>StandardOutPath</key>
-      <string>/usr/local/var/log/oauth-tunnel-client/oauth-tunnel-client.log</string>
+      <string>/opt/homebrew/var/log/oauth-tunnel-client/oauth-tunnel-client.log</string>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
- copied `oauth-tunnel-client.rb` to `oauth-tunnel-client-m1.rb`
- referring to the newly built package which includes `darwin-arm64` https://github.com/Shopify/oauth-tunnel-client/pull/133
- updated paths within `oauth-tunnel-client-m1.rb` to play well with the m1 and Monterey
- Bumped the version to 1.0.0

In `dev.yml` reference
```
- shopify/shopify/oauth-tunnel-client-m1:
        version: 1.0.0
```

tophat:
<img width="1231" alt="Screen Shot 2021-11-10 at 12 46 09 PM" src="https://user-images.githubusercontent.com/210335/141165667-b3937a63-57e6-4e19-83ae-9e08973e1a67.png">

