### PR TITLE
voucher_client-v2.7.0

### DIFF
--- a/voucher_client.rb
+++ b/voucher_client.rb
@@ -1,9 +1,18 @@
 class VoucherClient < Formula
   desc "Voucher Client is a tool for connecting to a running Voucher server."
-  homepage "https://github.com/Shopify/voucher"
-  url "https://github.com/Shopify/voucher/releases/download/v2.5.2/voucher_client_2.5.2_Darwin_x86_64.tar.gz"
-  version "v2.5.2"
-  sha256 "f2d121409fe6d7619497be6efd68daca1aaeb0ffcd9d054b389fbdb95b5f48a8"
+  homepage "https://github.com/grafeas/voucher"
+  version "2.7.0"
+
+  case
+  when OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/grafeas/voucher/releases/download/v#{version}/voucher_client_#{version}_Darwin_x86_64.tar.gz"
+    sha256 "76e374a99a545a0d9fe45fa581766288f52061ed569db8a85174a9aca2d183ba"
+  when OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/grafeas/voucher/releases/download/v#{version}/voucher_client_#{version}_Darwin_arm64.tar.gz"
+    sha256 "a8e184d6820a831c47636d1a7544c012b0fae3d76659aeccdedbf8654b0199e3"
+  else
+    odie "Unexpected platform!"
+  end
 
   def install
     bin.install "voucher_client"


### PR DESCRIPTION
* on [2020-11-18](https://cloud.google.com/blog/products/devops-sre/introducing-voucher-service-help-secure-container-supply-chain),  `voucher` migrated to the `grafeas` organization which broke this formula.
* on `2021-09-14`, voucher-v2.6.0 added binaries for the `darwin/arm64` platform
* on `2022-01-04` the latest and greatest voucher-v2.7.0 was released

This PR rolls these changes up such that https://github.com/grafeas/voucher/releases/tag/v2.7.0 is the supported version of voucher.

