### PR TITLE
Depend on ruby 3

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -92,6 +92,7 @@ class ShopifyCli < Formula
         #!#{ruby_bin}/ruby --disable-gems
         ENV['GEM_HOME']="#{prefix}"
         ENV['GEM_PATH']="#{prefix}"
+        ENV['RUBY_BINDIR']="#{ruby_bin}/"
         require 'rubygems'
         $:.unshift(#{ruby_libs.map(&:inspect).join(",")})
         load "#{file}"

--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -48,7 +48,7 @@ class ShopifyCli < Formula
   url "shopify-cli", using: RubyGemsDownloadStrategy
   version "2.8.0"
   sha256 "92c60b57ca784d8bed6378de6a31444523b91026e594e9db56c85b40ebfb3b78"
-  depends_on "ruby"
+  depends_on "ruby" => "3"
   depends_on "git"
 
   def install


### PR DESCRIPTION
The goal here is to make sure the CLI is always going to run on a modern Ruby. For this purpose, we'll upgrade the dependency to Ruby 3 to ensure a modern Ruby is installed.

We also add an ENV variable when running this way, to allow the CLI to be sure to use the correct Ruby version when installing gems and the like. Otherwise we've seen the CLI install gems on e.g. system Ruby and have the gem executables (mainly `rails`) pinned to that Ruby version.