### PR TITLE
Restore Shopify CLI Ruby version fixes

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -48,7 +48,7 @@ class ShopifyCli < Formula
   url "shopify-cli", using: RubyGemsDownloadStrategy
   version "2.9.0"
   sha256 "1752b9f9cf3c23ac528ba73d405ef9a0cf9d92747ac43e6e36a6e074fe1dde75"
-  depends_on "ruby"
+  depends_on "ruby" => "3"
   depends_on "git"
 
   def install
@@ -92,6 +92,7 @@ class ShopifyCli < Formula
         #!#{ruby_bin}/ruby --disable-gems
         ENV['GEM_HOME']="#{prefix}"
         ENV['GEM_PATH']="#{prefix}"
+        ENV['RUBY_BINDIR']="#{ruby_bin}/"
         require 'rubygems'
         $:.unshift(#{ruby_libs.map(&:inspect).join(",")})
         load "#{file}"


### PR DESCRIPTION
These were introduced in  https://github.com/Shopify/homebrew-shopify/pull/335 and accidentally deleted in https://github.com/Shopify/homebrew-shopify/pull/336