### PR TITLE
voucher_client: linux support

### DIFF
--- a/voucher_client.rb
+++ b/voucher_client.rb
@@ -10,6 +10,12 @@ class VoucherClient < Formula
   when OS.mac? && Hardware::CPU.arm?
     url "https://github.com/grafeas/voucher/releases/download/v#{version}/voucher_client_#{version}_Darwin_arm64.tar.gz"
     sha256 "a8e184d6820a831c47636d1a7544c012b0fae3d76659aeccdedbf8654b0199e3"
+  when OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/grafeas/voucher/releases/download/v#{version}/voucher_client_#{version}_Linux_x86_64.tar.gz"
+    sha256 "bc95e43ca73c182bf4671ebede8a14ffc85139b654df2f4d72429a39a2ce1352"
+  when OS.linux? && Hardware::CPU.arm?
+    url "https://github.com/grafeas/voucher/releases/download/v#{version}/voucher_client_#{version}_Linux_arm64.tar.gz"
+    sha256 "8254553fb0148eb40fed1bb69285a1a2d9037e8c1079bfcf7b3023b4f361954d"
   else
     odie "Unexpected platform!"
   end


### PR DESCRIPTION
Add `linux/amd64` and `linux/arm64` binaries to voucher_client v2.7.0.
This fixes an issues where the "Unsupported platform" error would cause tapping to fail outside of MacOS.

Checksums should match https://github.com/grafeas/voucher/releases/download/v2.7.0/checksums.txt