### PR TITLE
Support oauth tunnel on linux

### DIFF
--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -1,4 +1,3 @@
-
 class OauthTunnelClient < Formula
   desc 'Create a secure local proxy with Shopify GCP services'
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
@@ -20,7 +19,6 @@ class OauthTunnelClient < Formula
   end
 
   def install
-    ENV["HOMEBREW_OAUTH_TUNNEL_CLIENT__BIN_PATH"] = bin
     bin.install({@@binary_name => 'oauth-tunnel-client'})
     mkdir_p var/"log/oauth-tunnel-client"
   end

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -4,6 +4,8 @@ class OauthTunnelClient < Formula
   url 'https://storage.googleapis.com/binaries.shopifykloud.com/oauth-tunnel/oauth-tunnel-client-c3219ecfeef1965c6524040f99aea53bdbfde9af.tar.gz'
   sha256 'c1b3d5b5ee6b92f4f44795b23e76742398759f21b235a386f7cf9d507cbc099a'
   version "1.0.0"
+  plist_options manual: "export GIN_MODE=release && #{HOMEBREW_PREFIX}/opt/oauth-tunnel-client/bin/oauth-tunnel-client"
+
 
   case
   when OS.mac? && Hardware::CPU.intel?
@@ -22,6 +24,7 @@ class OauthTunnelClient < Formula
     bin.install({@@binary_name => 'oauth-tunnel-client'})
     mkdir_p var/"log/oauth-tunnel-client"
   end
+
   def plist
     home = Dir.home
     <<~EOS

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -5,8 +5,18 @@ class OauthTunnelClient < Formula
   sha256 'c1b3d5b5ee6b92f4f44795b23e76742398759f21b235a386f7cf9d507cbc099a'
   version "1.0.0"
 
-  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
-  @@binary_name = "oauth-tunnel-client_darwin_#{arch}" 
+  case
+  when OS.mac? && Hardware::CPU.intel?
+    @@binary_name = "oauth-tunnel-client_darwin_amd64" 
+  when OS.mac? && Hardware::CPU.arm?
+    @@binary_name = "oauth-tunnel-client_darwin_arm64" 
+  when OS.linux? && Hardware::CPU.intel?
+    @@binary_name = "oauth-tunnel-client_linux_amd64" 
+  when OS.linux? && Hardware::CPU.arm?
+    @@binary_name = "oauth-tunnel-client_linux_arm64" 
+  else
+    odie "Unexpected platform!"
+  end
 
   def install
     bin.install({@@binary_name => 'oauth-tunnel-client'})

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -10,6 +10,8 @@ class OauthTunnelClient < Formula
     @@binary_name = "oauth-tunnel-client_darwin_amd64" 
   when OS.mac? && Hardware::CPU.arm?
     @@binary_name = "oauth-tunnel-client_darwin_arm64" 
+  when OS.linux? && Hardware::CPU.is_32_bit?
+    @@binary_name = "oauth-tunnel-client_linux_386"
   when OS.linux? && Hardware::CPU.intel?
     @@binary_name = "oauth-tunnel-client_linux_amd64" 
   when OS.linux? && Hardware::CPU.arm?

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -1,3 +1,4 @@
+
 class OauthTunnelClient < Formula
   desc 'Create a secure local proxy with Shopify GCP services'
   homepage 'https://github.com/Shopify/oauth-tunnel-client'
@@ -9,11 +10,9 @@ class OauthTunnelClient < Formula
   when OS.mac? && Hardware::CPU.intel?
     @@binary_name = "oauth-tunnel-client_darwin_amd64" 
   when OS.mac? && Hardware::CPU.arm?
-    @@binary_name = "oauth-tunnel-client_darwin_arm64" 
-  when OS.linux? && Hardware::CPU.is_32_bit?
-    @@binary_name = "oauth-tunnel-client_linux_386"
+    @@binary_name = "oauth-tunnel-client_darwin_arm64"
   when OS.linux? && Hardware::CPU.intel?
-    @@binary_name = "oauth-tunnel-client_linux_amd64" 
+    @@binary_name = "oauth-tunnel-client_linux_386"
   when OS.linux? && Hardware::CPU.arm?
     @@binary_name = "oauth-tunnel-client_linux_arm64" 
   else
@@ -21,6 +20,7 @@ class OauthTunnelClient < Formula
   end
 
   def install
+    ENV["HOMEBREW_OAUTH_TUNNEL_CLIENT__BIN_PATH"] = bin
     bin.install({@@binary_name => 'oauth-tunnel-client'})
     mkdir_p var/"log/oauth-tunnel-client"
   end


### PR DESCRIPTION
Add support to install Linux Binary if the device is running Linux.

Homebrew on Linux does not support `services` so cannot start services but `export GIN_MODE=release && $(brew --prefix oauth-tunnel-client)/bin/oauth-tunnel-client` will run the binary. 

Available Binaries
<img width="201" alt="Screen Shot 2022-01-26 at 7 05 42 PM" src="https://user-images.githubusercontent.com/11271486/151267452-a7ef4ff4-5ae3-46ae-ae6a-0686d69f41d3.png">


Tested on Linux:
<img width="1158" alt="Screen Shot 2022-01-26 at 6 21 36 PM" src="https://user-images.githubusercontent.com/11271486/151263769-2666cf78-c6da-4141-9a46-f3959f44bcfc.png">

Testes on Mac:
<img width="1277" alt="Screen Shot 2022-01-26 at 6 22 37 PM" src="https://user-images.githubusercontent.com/11271486/151263779-bcb07188-0bf6-4827-a2ad-2ff1fc01ad62.png">

