### PR TITLE
Bumping version of trino-cli and trino-jdbc to 370.

### DIFF
--- a/trino-cli.rb
+++ b/trino-cli.rb
@@ -1,9 +1,9 @@
 class TrinoCli < Formula
   desc "Trino CLI executable to connect and run queries against Trino"
   homepage "https://trino.io/docs/current/installation/cli.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-cli/362/trino-cli-362-executable.jar"
-  sha256 "3fe3ec6d003aaceeb2b0c2701b02409c2254a7321fd49ceb8c6d123a5e444ba4"
-  version "362"
+  url "https://repo1.maven.org/maven2/io/trino/trino-cli/370/trino-cli-370-executable.jar"
+  sha256 "9e8b66175b9716ca942ac63b24f62ebdcc7d47e1b39a0b5c124c89db31c2b9b4"
+  version "370"
 
   def install
     bin.install "trino-cli-#{version}-executable.jar" => "trino"

--- a/trino-jdbc.rb
+++ b/trino-jdbc.rb
@@ -1,9 +1,9 @@
 class TrinoJdbc < Formula
   desc "JAR file for connecting to Trino over JDBC"
   homepage "https://trino.io/docs/current/installation/jdbc.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/362/trino-jdbc-362.jar"
-  sha256 "740525691b46dfe389fc597e13007b81a77f3911dc88154d8dec397aa2b1e86d"
-  version "362"
+  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/370/trino-jdbc-370.jar"
+  sha256 "8c2c5e658931af4bc1cb82e5ea5a1f05ae5769c6ac7be713c6a6a51d655b9958"
+  version "370"
 
   def install
     libexec.install "trino-jdbc-#{version}.jar"


### PR DESCRIPTION
This is needed to include M1 fixes to trino-cli included in 370. https://github.com/trinodb/trino/pull/10177

Should trino-jdbc be bumped as well?


Based off of https://github.com/Shopify/homebrew-shopify/pull/298
🎩 
```
danielcole@Daniels-MacBook-Pro homebrew-shopify % brew install --build-from-source ./trino-cli.rb
Error: Failed to load cask: ./trino-cli.rb
Cask 'trino-cli' is unreadable: wrong constant name #<Class:0x000000013084d3f8>
Warning: Treating ./trino-cli.rb as a formula.
trino-cli 362 is already installed but outdated (so it will be upgraded).
==> Downloading https://repo1.maven.org/maven2/io/trino/trino-cli/370/trino-cli-370-executable.jar
######################################################################## 100.0%
==> Upgrading trino-cli
  362 -> 370 

🍺  /opt/homebrew/Cellar/trino-cli/370: 3 files, 9.9MB, built in 1 second
==> Running `brew cleanup trino-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/trino-cli/362... (3 files, 9.7MB)
```

```
danielcole@Daniels-MacBook-Pro homebrew-shopify % brew install --build-from-source ./trino-jdbc.rb
Error: Failed to load cask: ./trino-jdbc.rb
Cask 'trino-jdbc' is unreadable: wrong constant name #<Class:0x0000000139209380>
Warning: Treating ./trino-jdbc.rb as a formula.
==> Downloading https://repo1.maven.org/maven2/io/trino/trino-jdbc/370/trino-jdbc-370.jar
######################################################################## 100.0%
🍺  /opt/homebrew/Cellar/trino-jdbc/370: 3 files, 6.4MB, built in 1 second
==> Running `brew cleanup trino-jdbc`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```