### PR TITLE
Update buildkite agent to 3.33.3 for x86 machines

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,14 +3,13 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
+    version "3.33.3"
     if Hardware::CPU.arm?
-      version "3.33.3"
       url     "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-arm64-3.33.3.tar.gz"
-      sha256  "1f7ad047f264750fb4b98e9cb7a439a768496358b544641da904913800d035c8" 
+      sha256  "1f7ad047f264750fb4b98e9cb7a439a768496358b544641da904913800d035c8"
     else
-      version "3.15.2"
-      url     "https://github.com/buildkite/agent/releases/download/v3.15.2/buildkite-agent-darwin-amd64-3.15.2.tar.gz"
-      sha256  "6cb1949b106c92d33dee51da3febcb9a271a1e2ab1c55bb729c043bdea3c8502"
+      url     "https://github.com/buildkite/agent/releases/download/v3.33.3/buildkite-agent-darwin-amd64-3.33.3.tar.gz"
+      sha256  "19f108798308a98dcdddb750faea1f8fa8dc832501fa46757ca4b462b9eb58a0"
     end
   end
 


### PR DESCRIPTION
Issue: https://github.com/Shopify/mac-infra/issues/457

This change upgrades and pins the buildkite agent to the latest version (3.33.3) for the x86 machines. The ARM machines are already upto date i.e. the version is already pinned @ 3.33.3 for the ARM machines.

This change is copied from: https://github.com/buildkite/homebrew-buildkite/blob/master/buildkite-agent.rb
