### PR TITLE
Add `trino-certloader` cask

### DIFF
--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -9,13 +9,13 @@ class OauthTunnelClient < Formula
 
   case
   when OS.mac? && Hardware::CPU.intel?
-    @@binary_name = "oauth-tunnel-client_darwin_amd64" 
+    @@binary_name = "oauth-tunnel-client_darwin_amd64"
   when OS.mac? && Hardware::CPU.arm?
     @@binary_name = "oauth-tunnel-client_darwin_arm64"
   when OS.linux? && Hardware::CPU.intel?
     @@binary_name = "oauth-tunnel-client_linux_386"
   when OS.linux? && Hardware::CPU.arm?
-    @@binary_name = "oauth-tunnel-client_linux_arm64" 
+    @@binary_name = "oauth-tunnel-client_linux_arm64"
   else
     odie "Unexpected platform!"
   end

--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -70,18 +70,19 @@ class TrinoCertloader < Formula
     end
   end
 
+  @@version = "0.1.1"
 
   desc 'Manage mTLS certificates for Conductor and Trino'
   homepage 'https://github.com/Shopify/certloader'
-  version "0.1.1"
+  version @@version
   plist_options manual: "export GIN_MODE=release && #{HOMEBREW_PREFIX}/opt/trino-certloader/bin/trino-certloader"
 
   case
   when OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/Shopify/certloader/releases/download/0.1.1/certloader_darwin_arm64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    url "https://github.com/Shopify/certloader/releases/download/#{@@version}/certloader_darwin_arm64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
     sha256 '3f9a180af25ab655d21ddc6bdf0c7e0a212d1bba0f0ad379b358ad5d31051778'
   when OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/Shopify/certloader/releases/download/0.1.1/certloader_darwin_amd64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    url "https://github.com/Shopify/certloader/releases/download/#{@@version}/certloader_darwin_amd64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
     sha256 'd90bac7df7a028c948be01a9e9e0cc44900e52853ccf6374591af9b78f191f0a'
   else
     odie "Unexpected platform!"

--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -80,10 +80,10 @@ class TrinoCertloader < Formula
   case
   when OS.mac? && Hardware::CPU.arm?
     url "https://github.com/Shopify/certloader/releases/download/#{@@version}/certloader_darwin_arm64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 '3f9a180af25ab655d21ddc6bdf0c7e0a212d1bba0f0ad379b358ad5d31051778'
+    sha256 '5ae8f3f4d238e9981dad8183c0a1adbfa38140df32b80486df47d399d8f2470f'
   when OS.mac? && Hardware::CPU.intel?
     url "https://github.com/Shopify/certloader/releases/download/#{@@version}/certloader_darwin_amd64.tar.gz", using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 'd90bac7df7a028c948be01a9e9e0cc44900e52853ccf6374591af9b78f191f0a'
+    sha256 '6e126804d3c84a545ab94a7892b4d0f74d4da1c5bf7a3fe4b4a1265a5315c566'
   else
     odie "Unexpected platform!"
   end
@@ -111,8 +111,10 @@ class TrinoCertloader < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{bin}/trino-certloader</string>
-        <string>--no-tracing</string>
         <string>-o=#{var}/trino-certloader/certs</string>
+        <string>--no-tracing</string>
+        <string>--log-metrics</string>
+        <string>--combined-pem</string>
         <string>-vault.pki.path=certify/conductor/production</string>
         <string>-vault.auth.type=github</string>
         <string>-vault.auth.github.token.path=/opt/dev/var/private/git_credential_store</string>

--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -1,0 +1,63 @@
+class TrinoCertloader < Formula
+  desc 'Manage mTLS certificates for Conductor and Trino'
+  homepage 'https://github.com/Shopify/certloader'
+  url 'https://storage.googleapis.com/binaries.shopifykloud.com/certloader/certloader.target.zip'
+  sha256 '63200d5dc9536652ffccde46d69ee389a6a490593118bb953bca20c0499a5b16'
+  version "1.0.0"
+  plist_options manual: "export GIN_MODE=release && #{HOMEBREW_PREFIX}/opt/trino-certloader/bin/trino-certloader"
+
+  case
+  when OS.mac? && Hardware::CPU.intel?
+    @@binary_name = "certloader-darwin_amd64"
+  when OS.mac? && Hardware::CPU.arm?
+    @@binary_name = "certloader-darwin_arm64"
+  else
+    odie "Unexpected platform!"
+  end
+
+  def install
+    bin.install({@@binary_name => "trino-certloader"})
+    mkdir_p var/"log/trino-certloader"
+    mkdir_p var/"trino-certloader/certs"
+  end
+
+  def plist
+    home = Dir.home
+    <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>EnvironmentVariables</key>
+      <dict>
+       <key>GIN_MODE</key>
+       <string>release</string>
+      </dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{bin}/trino-certloader</string>
+        <string>--no-tracing</string>
+        <string>-o=#{var}/trino-certloader/certs</string>
+        <string>-vault.pki.path=certify/conductor/production</string>
+        <string>-vault.auth.type=github</string>
+        <string>-vault.auth.github.token.path=/opt/dev/var/private/git_credential_store</string>
+        <string>-sync.interval=10s</string>
+        <string>-cert.duration=1h</string>
+        <string>-cert.renew-before=59m0s</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/trino-certloader/trino-certloader_err.log</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/trino-certloader/trino-certloader.log</string>
+    </dict>
+    </plist>
+    EOS
+  end
+  test do
+    system "#{bin}/#{@@binary_name}", "--help"
+  end
+end


### PR DESCRIPTION
Conductor/Trino will use `certloader` run as a Homebrew service powered by launchd and Mac's plist files similar to how the `oauth-tunnel-client` is ran to automatically manage mTLS certificates.

This PR will enable:

```bash
# auth with github (if not done already)
dev github auth

# install and start the cask
brew install trino-certloader
brew services start trino-certloader

# verify that the service was installed and running
➜ brew services info trino-certloader
trino-certloader (homebrew.mxcl.trino-certloader)
Running: ✔
Loaded: ✔
Schedulable: ✘

# verify that certloader created the certs
➜ tree $(brew --prefix)/var/trino-certloader/certs/
/opt/homebrew/var/trino-certloader/certs/
├── ca.crt -> .current/ca.crt
├── cert_and_key.pem -> .current/cert_and_key.pem
├── tls.crt -> .current/tls.crt
└── tls.key -> .current/tls.key
```

`Certloader` uploads its released binaries as Github releases. Homebrew does not support private repos/releases by default so I found an example online for `GitHubPrivateRepositoryReleaseDownloadStrategy` which subclasses Homebrew's `CurlDownloadStrategy` and modified it to use the Github credentials from local dev.