### PR TITLE
Fix the shopify-cli formula

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -24,7 +24,7 @@ class ShopifyCli < Formula
       ohai("Fetching shopify-cli from gem source")
       cache.cd do
         ENV["GEM_SPEC_CACHE"] = "#{cache}/gem_spec_cache"
-        _, err, status = Open3.capture3("#{ruby_bin}/gem", "fetch", "shopify-cli", "--version", gem_version)
+        _, err, status = Open3.capture3("gem", "fetch", "shopify-cli", "--version", gem_version)
         unless status.success?
           odie err
         end
@@ -72,7 +72,7 @@ class ShopifyCli < Formula
     end
 
     system(
-      "#{ruby_bin}/gem",
+      "gem",
       "install",
       cached_download,
       "--no-document",


### PR DESCRIPTION
The shopify-cli Homebrew formula [causes installation issues](https://github.com/Shopify/shopify-cli/issues/2057#issuecomment-1060640948) when Ruby hasn't been previously installed through Homebrew. This PR fixes it.