### PR TITLE
Update Shopify CLI to 2.15.1

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -54,8 +54,8 @@ class ShopifyCli < Formula
   include RubyBin
 
   url "shopify-cli", using: RubyGemsDownloadStrategy
-  version "2.15.0"
-  sha256 "7643a8e39367100a1dc2c8e4d9f0d1315af4a016f35460216ad31318f6ad0298"
+  version "2.15.1"
+  sha256 "5f6773ce3560d2fa2a219fe6f41665020b801f217cca526b2341c1400c526c53"
   depends_on "ruby"
   depends_on "git"
 


### PR DESCRIPTION
I'm releasing a new version of the Shopify CLI, [2.15.1](https://github.com/Shopify/shopify-cli/releases/tag/v2.15.1)