### PR TITLE
Explicitly configure admin port for trino-certloader

### DIFF
--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -121,6 +121,7 @@ class TrinoCertloader < Formula
         <string>-sync.interval=10s</string>
         <string>-cert.duration=12h</string>
         <string>-cert.renew-before=11h59m</string>
+        <string>-admin-addr=:5201</string>
       </array>
       <key>RunAtLoad</key>
       <true/>


### PR DESCRIPTION
Explicitly configure admin port for trino-certloader to avoid other instances of certloader running on the same admin port 🙃 

After reinstalling `trino-certloader` from source with this change we can see the admin UI is served the at now specified port:

<img width="800" alt="Screen Shot 2022-05-19 at 2 12 18 PM" src="https://user-images.githubusercontent.com/8395995/169371277-e85a1174-8715-4be4-b93a-37c7f3b9afcd.png">

