### PR TITLE
Bump Trino packages to 381

### DIFF
--- a/trino-cli.rb
+++ b/trino-cli.rb
@@ -1,9 +1,9 @@
 class TrinoCli < Formula
   desc "Trino CLI executable to connect and run queries against Trino"
   homepage "https://trino.io/docs/current/installation/cli.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-cli/370/trino-cli-370-executable.jar"
-  sha256 "9e8b66175b9716ca942ac63b24f62ebdcc7d47e1b39a0b5c124c89db31c2b9b4"
-  version "370"
+  url "https://repo1.maven.org/maven2/io/trino/trino-cli/381/trino-cli-381-executable.jar"
+  sha256 "fb1ae6e4f976af7cb2906909d942b0cb15f9bf44e36c8d1547907be20684fe48"
+  version "381"
 
   def install
     bin.install "trino-cli-#{version}-executable.jar" => "trino"

--- a/trino-jdbc.rb
+++ b/trino-jdbc.rb
@@ -1,9 +1,9 @@
 class TrinoJdbc < Formula
   desc "JAR file for connecting to Trino over JDBC"
   homepage "https://trino.io/docs/current/installation/jdbc.html"
-  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/370/trino-jdbc-370.jar"
-  sha256 "8c2c5e658931af4bc1cb82e5ea5a1f05ae5769c6ac7be713c6a6a51d655b9958"
-  version "370"
+  url "https://repo1.maven.org/maven2/io/trino/trino-jdbc/381/trino-jdbc-381.jar"
+  sha256 "147aa35d016eeb14e0dea957f13692ec9fdb2398080d4ac4a164e1de28f3366b"
+  version "381"
 
   def install
     libexec.install "trino-jdbc-#{version}.jar"


### PR DESCRIPTION
sha generated using https://discourse.shopify.io/t/where-to-get-sha256-when-updating-or-adding-a-package-to-homebrew-shopify/25168