### PR TITLE
Add shopify-vips

### DIFF
--- a/shopify-vips.rb
+++ b/shopify-vips.rb
@@ -1,0 +1,72 @@
+class ShopifyVips < Formula
+  desc "Image processing library"
+  homepage "https://github.com/libvips/libvips"
+  url "https://github.com/libvips/libvips/archive/a129476f0febbca8e0df9c6766b141047a20e89c.tar.gz"
+  sha256 "0f4fd5e3dbf3c57bd82aa750d51eb9e0aa1b935323e9c542a212f5f59f3123e6"
+  version "8.13"
+  license "LGPL-2.1-or-later"
+  revision 1
+
+  depends_on "pkg-config" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "cairo"
+  depends_on "cfitsio"
+  depends_on "cgif"
+  depends_on "fftw"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "gdk-pixbuf"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "harfbuzz"
+  depends_on "hdf5"
+  depends_on "graphicsmagick"
+  depends_on "imath"
+  depends_on "jpeg-xl"
+  depends_on "libexif"
+  depends_on "libgsf"
+  depends_on "libheif"
+  depends_on "libimagequant"
+  depends_on "libmatio"
+  depends_on "libpng"
+  depends_on "librsvg"
+  depends_on "libtiff"
+  depends_on "libxml2"
+  depends_on "little-cms2"
+  depends_on "mozjpeg"
+  depends_on "openexr"
+  depends_on "openjpeg"
+  depends_on "openslide"
+  depends_on "pango"
+  depends_on "poppler"
+  depends_on "webp"
+
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
+
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --backend=ninja
+    ]
+
+    system "meson setup build", *args
+    system "meson", "install", "-C build"
+  end
+
+  test do
+    system "#{bin}/vips", "-l"
+    cmd = "#{bin}/vipsheader -f width #{test_fixtures("test.png")}"
+    assert_equal "8", shell_output(cmd).chomp
+
+    # --trellis-quant requires mozjpeg, vips warns if it's not present
+    cmd = "#{bin}/vips jpegsave #{test_fixtures("test.png")} #{testpath}/test.jpg --trellis-quant 2>&1"
+    assert_equal "", shell_output(cmd)
+
+    # [palette] requires libimagequant, vips warns if it's not present
+    cmd = "#{bin}/vips copy #{test_fixtures("test.png")} #{testpath}/test.png[palette] 2>&1"
+    assert_equal "", shell_output(cmd)
+  end
+end


### PR DESCRIPTION
Add **_shopify-vips_** recipe which is up-to-date with the [libvips](https://github.com/libvips/libvips) version [imagery4](https://github.com/Shopify/imagery4) uses in production.