### PR TITLE
fix #380

### DIFF
--- a/bazel@10.rb
+++ b/bazel@10.rb
@@ -16,7 +16,7 @@ class BazelAT10 < Formula
   end
 
   depends_on "openjdk@8"
-  depends_on :macos => :yosemite
+  depends_on :macos => :el_capitan
 
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"


### PR DESCRIPTION
fix depends_on :macos => :yosemite is deprecated

Yosemite is removed on this release https://github.com/Homebrew/brew/releases/tag/3.5.0