### PR TITLE
Handle multiple github auth creds in `dev github auth` credential store

### DIFF
--- a/merlin-certloader.rb
+++ b/merlin-certloader.rb
@@ -22,8 +22,9 @@ class MerlinCertloader < Formula
       end
 
       file = File.open(creds_filepath)
-      contents = file.read.strip!
-      creds = URI.parse(contents)
+      contents = file.read.strip!.split("\n")
+      latest_raw_creds = contents.last
+      creds = URI.parse(latest_raw_creds)
 
       @github_token = creds.password
 

--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -22,8 +22,9 @@ class TrinoCertloader < Formula
       end
 
       file = File.open(creds_filepath)
-      contents = file.read.strip!
-      creds = URI.parse(contents)
+      contents = file.read.strip!.split("\n")
+      latest_raw_creds = contents.last
+      creds = URI.parse(latest_raw_creds)
 
       @github_token = creds.password
 


### PR DESCRIPTION
Since we download `certloader` binaries from a Shopify private Github repository rather than a public bucket, we need to use a user's github auth credentials to download the binary. Previously it was assumed that a user only ever had a single auth credential in the `dev github auth` credential store, but some users have multiple if they refresh old expired tokens. This seems especially prevalent for longer tenured folks at Shopify.

We already [handle this in `certloader`](https://github.com/Shopify/certloader/blob/master/pkg/vault/github.go#L75-L78), but did not in the homebrew cask. Users would see errors when trying to install `trino-certloader` or `merlin-certloader` that looked like:

<img width="640" alt="Screen Shot 2022-07-21 at 2 22 26 PM" src="https://user-images.githubusercontent.com/8395995/180236383-8fc91f93-5411-4120-a97a-b9d9b93b1220.png">

I tested this by adding a dummy auth credential in my dev github auth creds store.

```
➜ cat /opt/dev/var/private/git_credential_store

https://foobar:ghp_barbarbar@github.com
https://austenLacy:ghp_REDACTED@github.com
```

```
➜ brew uninstall trino-certloader
```

```
➜ brew install --build-from-source ./trino-certloader.rb

Error: Failed to load cask: ./trino-certloader.rb
Cask 'trino-certloader' is unreadable: wrong constant name #<Class:0x0000000127c2cf18>
Warning: Treating ./trino-certloader.rb as a formula.
==> Downloading https://github.com/Shopify/certloader/releases/download/0.3.2/certloader_darwin_arm64.tar.gz
Already downloaded: /Users/austenlacy/Library/Caches/Homebrew/downloads/2860407bd0d8ff97e998a3d688f32de769350bd00c52760b866fcf995f016a56--certloader_darwin_arm64.tar.gz
Warning: Your Xcode (13.1) is outdated.
Please update to Xcode 13.4 (or delete it).
https://foobar:ghp_barbarbar@github.com
https://austenLacy:ghp_REDACTED@github.com
Xcode can be updated from the App Store.

==> Caveats
To restart trino-certloader after an upgrade:
  brew services restart trino-certloader
Or, if you don't want/need a background service you can just run:
  export GIN_MODE=release && /opt/homebrew/opt/trino-certloader/bin/trino-certloader
==> Summary
🍺  /opt/homebrew/Cellar/trino-certloader/0.3.2: 4 files, 17.4MB, built in 2 seconds
==> Running `brew cleanup trino-certloader`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/austenlacy/Library/Caches/Homebrew/trino-certloader--0.3.1.tar.gz... (5.6MB)
```

```
➜ brew services info trino-certloader
trino-certloader (homebrew.mxcl.trino-certloader)
Running: ✔
Loaded: ✔
Schedulable: ✘
User: austenlacy
```