### PR TITLE
shopify-vips: Add missing build dependency: gobject-introspection

### DIFF
--- a/shopify-vips.rb
+++ b/shopify-vips.rb
@@ -6,12 +6,13 @@ class ShopifyVips < Formula
   sha256 "8f7cb1806bcde834ee056853254d3643407ade280e24b6d1ddb8f155c9eb25f7"
   version "8.13"
   license "LGPL-2.1-or-later"
-  revision 5
+  revision 6
 
   depends_on "pkg-config" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "glib-utils" => :build
+  depends_on "gobject-introspection" => :build
   depends_on "cgif"
   depends_on "fftw"
   depends_on "freetype"


### PR DESCRIPTION
Add missing build dependency: `gobject-introspection`
Building `shopify-vips` started to fail out of the nowhere - I think we should consider adding tests to this repo at some point.

**Tophat instructions:**
```
brew install file:///Users/dbl/src/github.com/Shopify/homebrew-shopify/shopify-vips.rb
```
(path needs to be modified)

  