### PR TITLE
Update shopify-vips

### DIFF
--- a/shopify-vips.rb
+++ b/shopify-vips.rb
@@ -2,11 +2,11 @@ class ShopifyVips < Formula
   desc "Image processing library"
   conflicts_with "vips"
   homepage "https://github.com/libvips/libvips"
-  url "https://github.com/libvips/libvips/archive/v8.13.0.tar.gz"
-  sha256 "8f7cb1806bcde834ee056853254d3643407ade280e24b6d1ddb8f155c9eb25f7"
-  version "8.13.0"
+  url "https://github.com/libvips/libvips/archive/3b33d912c4e0be9e64be25a18252317dfb227dcf.tar.gz"
+  sha256 "b43a426e88422e12448fc5046f4c5548019aa8c94df8febcc4f149aebb3cf69a"
+  version "8.14.0"
   license "LGPL-2.1-or-later"
-  revision 7
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "meson" => :build


### PR DESCRIPTION
libjxl v0.7.0 made it into Homebrew. Let's update to latest libvips master.

**Tophat instructions:**
```
brew install file:///Users/dbl/src/github.com/Shopify/homebrew-shopify/shopify-vips.rb
```
(path needs to be modified)