### PR TITLE
Update Shopify CLI to 2.25.0

### DIFF
--- a/shopify-cli@2.rb
+++ b/shopify-cli@2.rb
@@ -10,7 +10,7 @@
 require "formula"
 require "fileutils"
 
-class ShopifyCli < Formula
+class ShopifyCliAT2 < Formula
   module RubyBin
     def ruby_bin
       Formula["ruby"].opt_bin


### PR DESCRIPTION
I'm releasing a new version of the Shopify CLI, [2.25.0](https://github.com/Shopify/shopify-cli/releases/tag/v2.25.0)