### PR TITLE
Update Shopify CLI to 2.29.0

### DIFF
--- a/shopify-cli.rb
+++ b/shopify-cli.rb
@@ -54,8 +54,8 @@ class ShopifyCli < Formula
   include RubyBin
 
   url "shopify-cli", using: RubyGemsDownloadStrategy
-  version "2.28.0"
-  sha256 "e944f114a4d110b030015e3185af50b1fdd31385dfcb99d6b55a9bcdf8bc6324"
+  version "2.29.0"
+  sha256 "28eb7ccd277ef3037f28d405cda6dcec41320926350be9e9a7445e5929a144bd"
   depends_on "ruby"
   depends_on "git"
 

--- a/shopify-cli@2.rb
+++ b/shopify-cli@2.rb
@@ -54,8 +54,8 @@ class ShopifyCliAT2 < Formula
   include RubyBin
 
   url "shopify-cli", using: RubyGemsDownloadStrategy
-  version "2.28.0"
-  sha256 "e944f114a4d110b030015e3185af50b1fdd31385dfcb99d6b55a9bcdf8bc6324"
+  version "2.29.0"
+  sha256 "28eb7ccd277ef3037f28d405cda6dcec41320926350be9e9a7445e5929a144bd"
   depends_on "ruby"
   depends_on "git"
 


### PR DESCRIPTION
I'm releasing a new version of the Shopify CLI, [2.29.0](https://github.com/Shopify/shopify-cli/releases/tag/v2.29.0)