### PR TITLE
Upgrade jdk 17 version

### DIFF
--- a/casks/zulu-jdk17.rb
+++ b/casks/zulu-jdk17.rb
@@ -1,16 +1,16 @@
 cask 'zulu-jdk17' do
 
   if Hardware::CPU.intel?
-    version '17.30.15,17.0.1'
-    sha256 '34311143c9da6f4993d073979f64c1a4272990261a429dcb9e4a231c6236bccf'
+    version '17.38.21,17.0.5'
+    sha256 'eb3b4e8e8155ac7ad1e46b2f2715ebcc9059c0a657c88f0babddb126a8773290'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
 
-    depends_on macos: '>= :high_sierra'
+    depends_on macos: '>= :mojave'
   else
-    version '17.30.15,17.0.1'
-    sha256 '132ba9bed55c54eeafdee3472468bde1e740d13a1dbb644f76dba0eaa585f1f2'
+    version '17.38.21,17.0.5'
+    sha256 '73b0732f78726acca5ad8ceb1e43898d8c7982c4debc24e88b4fcd12d6e8c07a'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'


### PR DESCRIPTION
Trino 400 requires JDK 17 > 17.04
This PR Upgrades the JDK 17 version to 17.05