### PR TITLE
Add libgda@5

### DIFF
--- a/libgda@5.rb
+++ b/libgda@5.rb
@@ -1,0 +1,51 @@
+class LibgdaAT5 < Formula
+  desc "Provides unified data access to the GNOME project"
+  homepage "https://www.gnome-db.org/"
+  url "https://download.gnome.org/sources/libgda/5.2/libgda-5.2.10.tar.xz"
+  sha256 "6f6cdf7b8053f553b907e0c88a6064eb48cf2751852eb24323dcf027792334c8"
+  license "GPL-2.0-or-later"
+
+  depends_on "gobject-introspection" => :build
+  depends_on "intltool" => :build
+  depends_on "itstool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "libgcrypt"
+  depends_on "libgee"
+  depends_on "openssl@1.1"
+  depends_on "readline"
+
+  uses_from_macos "perl" => :build
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  def install
+    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" unless OS.mac?
+
+    # this build uses the sqlite source code that comes with libgda,
+    # as opposed to using the system or brewed sqlite3, which is not supported on macOS,
+    # as mentioned in https://github.com/GNOME/libgda/blob/95eeca4b0470f347c645a27f714c62aa6e59f820/libgda/sqlite/README#L31
+
+    system "./configure", "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      "--disable-binreloc",
+      "--disable-gtk-doc",
+      "--without-java",
+      "--enable-introspection",
+      "--enable-system-sqlite=no"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/gda-sql", "-v"
+  end
+end
+


### PR DESCRIPTION
Homebrew upgraded its libgda to 6 but some software still relies on version 5.