### PR TITLE
Replace plist with service directive

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -59,25 +59,8 @@ class Toxiproxy < Formula
     end
   end
 
-  plist_options manual: "toxiproxy"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/toxiproxy-server</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-      </dict>
-    </plist>
-    EOS
+  service do
+    run [bin/"toxiproxy-server"]
+    keep_alive true
   end
 end


### PR DESCRIPTION
Replace plist_options with service block:

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/shopify/homebrew-shopify/toxiproxy.rb:62
```