### PR TITLE
Replace deprecated plist methods with service blocks

### DIFF
--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -114,58 +114,14 @@ class BuildkiteAgent < Formula
     EOS
   end
 
-  plist_options :manual => "buildkite-agent start"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}/bin</string>
-
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{HOMEBREW_PREFIX}/bin/buildkite-agent</string>
-          <string>start</string>
-          <string>--config</string>
-          <string>#{agent_config_path}</string>
-          <!--<string>--debug</string>-->
-        </array>
-
-        <key>EnvironmentVariables</key>
-        <dict>
-          <key>PATH</key>
-          <string>#{HOMEBREW_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        </dict>
-
-        <key>RunAtLoad</key>
-        <true/>
-
-        <key>KeepAlive</key>
-        <dict>
-          <key>SuccessfulExit</key>
-          <false/>
-        </dict>
-
-        <key>ProcessType</key>
-        <string>Interactive</string>
-
-        <key>ThrottleInterval</key>
-        <integer>30</integer>
-
-        <key>StandardOutPath</key>
-        <string>#{var}/log/buildkite-agent.log</string>
-
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/buildkite-agent.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"buildkite-agent", "start", "--config", agent_config_path]
+    process_type :interactive
+    working_dir HOMEBREW_PREFIX
+    environment_variables PATH: std_service_path_env
+    keep_alive { succesful_exit: false }
+    log_path var/"log/buildkite-agent.log"
+    error_log_path var/"log/buildkite-agent.log"
   end
 
   def agent_token_reminder

--- a/oauth-tunnel-client.rb
+++ b/oauth-tunnel-client.rb
@@ -4,8 +4,6 @@ class OauthTunnelClient < Formula
   url 'https://storage.googleapis.com/binaries.shopifykloud.com/oauth-tunnel/oauth-tunnel-client-c3219ecfeef1965c6524040f99aea53bdbfde9af.tar.gz'
   sha256 'c1b3d5b5ee6b92f4f44795b23e76742398759f21b235a386f7cf9d507cbc099a'
   version "1.0.0"
-  plist_options manual: "export GIN_MODE=release && #{HOMEBREW_PREFIX}/opt/oauth-tunnel-client/bin/oauth-tunnel-client"
-
 
   case
   when OS.mac? && Hardware::CPU.intel?
@@ -25,34 +23,13 @@ class OauthTunnelClient < Formula
     mkdir_p var/"log/oauth-tunnel-client"
   end
 
-  def plist
-    home = Dir.home
-    <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>EnvironmentVariables</key>
-      <dict>
-       <key>GIN_MODE</key>
-       <string>release</string>
-      </dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{bin}/oauth-tunnel-client</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/oauth-tunnel-client/oauth-tunnel-client_err.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/oauth-tunnel-client/oauth-tunnel-client.log</string>
-    </dict>
-    </plist>
-    EOS
+  service do
+    run [bin/"oauth-tunnel-client"]
+    environment_variables GIN_MODE: "release"
+    log_path var/"log/oauth-tunnel-client/oauth-tunnel-client.log"
+    error_log_path var/"log/oauth-tunnel-client/oauth-tunnel-client_err.log"
   end
+
   test do
     system "#{bin}/#{@@binary_name}", "version"
   end

--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -76,7 +76,6 @@ class TrinoCertloader < Formula
   desc 'Manage mTLS certificates for Conductor and Trino'
   homepage 'https://github.com/Shopify/certloader'
   version @@version
-  plist_options manual: "export GIN_MODE=release && #{HOMEBREW_PREFIX}/opt/trino-certloader/bin/trino-certloader"
 
   case
   when OS.mac? && Hardware::CPU.arm?
@@ -95,45 +94,26 @@ class TrinoCertloader < Formula
     mkdir_p var/"trino-certloader/certs"
   end
 
-  def plist
-    home = Dir.home
-    <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>EnvironmentVariables</key>
-      <dict>
-       <key>GIN_MODE</key>
-       <string>release</string>
-      </dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{bin}/trino-certloader</string>
-        <string>-o=#{var}/trino-certloader/certs</string>
-        <string>--no-tracing</string>
-        <string>--log-metrics</string>
-        <string>--combined-pem</string>
-        <string>-vault.pki.path=certify/conductor/production</string>
-        <string>-vault.auth.type=github</string>
-        <string>-vault.auth.github.token.path=/opt/dev/var/private/git_credential_store</string>
-        <string>-sync.interval=10s</string>
-        <string>-cert.duration=12h</string>
-        <string>-cert.renew-before=11h59m</string>
-        <string>-admin-addr=:5201</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/trino-certloader/trino-certloader_err.log</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/trino-certloader/trino-certloader.log</string>
-    </dict>
-    </plist>
-    EOS
+  service do
+    run [
+      bin/"trino-certloader",
+      "-o=#{var}/trino-certloader/certs",
+      "--no-tracing",
+      "--log-metrics",
+      "--combined-pem",
+      "-vault.pki.path=certify/conductor/production",
+      "-vault.auth.type=github",
+      "-vault.auth.github.token.path=/opt/dev/var/private/git_credential_store",
+      "-sync.interval=10s",
+      "-cert.duration=12h",
+      "-cert.renew-before=11h59m",
+      "-admin-addr=:5201",
+    ]
+    environment_variables GIN_MODE: "release"
+    log_path var/"log/trino-certloader/trino-certloader_err.log"
+    error_log_path var/"log/trino-certloader/trino-certloader.log"
   end
+
   test do
     system "#{bin}/certloader", "--help"
   end


### PR DESCRIPTION
Brew started complaining during updates with the following:

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the shopify/shopify tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/shopify/homebrew-shopify/oauth-tunnel-client.rb:7
```