### PR TITLE
Set url in trino-certloader constructor.

### DIFF
--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -12,6 +12,7 @@ class TrinoCertloader < Formula
       super
       set_github_token
       parse_url_pattern
+      @url = download_url
     end
 
     def set_github_token


### PR DESCRIPTION
not sure what went wrong here but setting the download url in the constructor fixed everything. our overide of `_fetch` is no longer being called, but i don't really understand why (maybe something to do with private overides ?).

