### PR TITLE
Update Merlin-Certloader to use Google CA instead of Vault 

### DIFF
--- a/merlin-certloader.rb
+++ b/merlin-certloader.rb
@@ -72,7 +72,7 @@ class MerlinCertloader < Formula
     end
   end
 
-  @@version = "0.4.3"
+  @@version = "0.6.0"
 
   desc 'Manage mTLS certificates for Merlin'
   homepage 'https://github.com/Shopify/certloader'
@@ -103,7 +103,7 @@ class MerlinCertloader < Formula
         "--no-tracing",
         "--log-metrics",
         "--combined-pem",
-        "-googleca.ca-pool=merlin-adhoc-root"
+        "-googleca.ca-pool=merlin-adhoc-root",
         "-googleca.issuing-ca-id=merlin-adhoc-root",
         "-googleca.location=us-central1",
         "-googleca.key-algorithm=RSA",


### PR DESCRIPTION
See https://github.com/Shopify/terraform-the-cloud/pull/20905/files and https://github.com/Shopify/merlin-projects/issues/4760 