### PR TITLE
fix: stop renewing certs every minute

### DIFF
--- a/trino-certloader.rb
+++ b/trino-certloader.rb
@@ -104,12 +104,11 @@ class TrinoCertloader < Formula
       "--combined-pem",
       "-googleca.ca-pool=trino-conductor-root",
       "-googleca.issuing-ca-id=trino-conductor-root",
-      "-googleca.location=us-central1", 
-      "-googleca.key-algorithm=RSA", 
+      "-googleca.location=us-central1",
+      "-googleca.key-algorithm=RSA",
       "-googleca.project=shopify-certificate-authority",
-      "-sync.interval=10s",
-      "-cert.duration=12h",
-      "-cert.renew-before=11h59m",
+      "-sync.interval=60m",
+      "-cert.duration=24h",
       "-admin-addr=:5201",
     ]
     environment_variables GIN_MODE: "release"


### PR DESCRIPTION
Based on google certificate authority logs trino certs are being requested every minute by this service.

Looks like this is because the renew_before time is set to 11h59m and the cert duration is 12h. This effectively will make certloader request a new cert every minute.

This change proposes that we extend the cert duration to 24 hours and leave the default renew_before setting of 1 hour.

Sample logs for an individual over the past hour
![Screenshot 2023-09-21 at 3 08 35 PM](https://github.com/Shopify/homebrew-shopify/assets/8786230/cd814101-3907-47ef-ae97-9890dfb12df2)
