### PR TITLE
Update hashes and versions for toxiproxy 2.7.0

### DIFF
--- a/toxiproxy.rb
+++ b/toxiproxy.rb
@@ -3,7 +3,7 @@
 # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 
 class Toxiproxy < Formula
-  app_version = "2.6.0"
+  app_version = "2.7.0"
   homepage "https://github.com/Shopify/toxiproxy"
   license "MIT"
   version app_version
@@ -11,16 +11,16 @@ class Toxiproxy < Formula
   case
   when OS.mac? && Hardware::CPU.intel?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-darwin-amd64"
-    sha256 "7df7a295adaeddd8654be00cb5fa6363100d745c151e7e42649a554767c50c0c"
+    sha256 "8f439c3abea34c20ef615aa46368e883ec7e1c9c904070f3be7f05f90f9ac51b"
   when OS.mac? && Hardware::CPU.arm?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-darwin-arm64"
-    sha256 "cfc033ef0e1c402f1c84789a88a7acd79b4c421f89839458a8d21ee8bc69801f"
+    sha256 "619148a5af477aa83f642e7ed0f5de05f005ac493fae3ec06ece00a22df4a2cb"
   when OS.linux? && Hardware::CPU.intel?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-linux-amd64"
-    sha256 "bf693bf8d7bdfd39d71f0a1a87fff5895db6d56565d06f3586aa9b271d1dc659"
+    sha256 "4957d7e8949ecc54f798fdfc8901c022ff24cd4394493be9e321a3e3d4556ac0"
   when OS.linux? && Hardware::CPU.arm?
     url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-server-linux-arm64"
-    sha256 "6cd8d681d3c39ffa59877eb56a29d4887876d4740ac07afbb26e1aa3c3ba7dbe"
+    sha256 "7f63da3a5b15a8db31cf05379d09fda9bce862288c7f70912c78237ce030b0c9"
   else
     odie "Unexpected platform!"
   end
@@ -29,16 +29,16 @@ class Toxiproxy < Formula
     case
     when OS.mac? && Hardware::CPU.intel?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-darwin-amd64"
-      sha256 "6e3bc4fcf127b8cc2c6dd306e3157fb16579c510b725eee0a1ba8f8288b3faff"
+      sha256 "b2d128927876cb6eab0d5223c75cba5afa9ce8c64da649d58a0865a4deba2af5"
     when OS.mac? && Hardware::CPU.arm?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-darwin-arm64"
-      sha256 "c45b7a2ad98536e7d5b55ccf70b45b0f2b9128e7892c4304ca8d7e4d786b2235"
+      sha256 "6588645d7d8e94243f8feec828edfb5cb090345ddf9023cc145ea553835e502d"
     when OS.linux? && Hardware::CPU.intel?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-linux-amd64"
-      sha256 "186fc2cc4fc9a077a2bcb3bbed31f974f1f4ff19d7009148b68b442b06796c17"
+      sha256 "d41ac1698f4d4c7d27d42fd00ab5bcf48d10a163aadca8e61f1270e54f7bec9e"
     when OS.linux? && Hardware::CPU.arm?
       url "https://github.com/Shopify/toxiproxy/releases/download/v#{app_version}/toxiproxy-cli-linux-arm64"
-      sha256 "20959bc0c5ee02d225d477d5db372b8fe1b6142381b82272c1ba65efcee7c39f"
+      sha256 "ea237da7299ea9751a0fb988d6c47c73326e61515c9b4d6232b5fb9b3eb2e21c"
     end
   end
 


### PR DESCRIPTION
Toxiproxy 2.7.0 has been released.