### PR TITLE
shopify-vips: update to v8.15.1

### DIFF
--- a/shopify-vips.rb
+++ b/shopify-vips.rb
@@ -2,11 +2,11 @@ class ShopifyVips < Formula
   desc "Image processing library"
   conflicts_with "vips"
   homepage "https://github.com/libvips/libvips"
-  url "https://github.com/libvips/libvips/releases/download/v8.15.0/vips-8.15.0.tar.xz"
-  sha256 "d33f81c6ab4bd1faeedc36dc32f880b19e9d5ff69b502e59d175332dfb8f63f1"
-  version "8.15.0"
+  url "https://github.com/libvips/libvips/releases/download/v8.15.1/vips-8.15.1.tar.xz"
+  sha256 "06811f5aed3e7bc03e63d05537ff4b501de5283108c8ee79396c60601a00830c"
+  version "8.15.1"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 0
 
   depends_on "pkg-config" => :build
   depends_on "meson" => :build


### PR DESCRIPTION
Update to v8.15.1
**Changes since v8.15.0:** https://github.com/libvips/libvips/releases/tag/v8.15.1
