### PR TITLE
Remove deprecated depends_on macos from zulu-jdk casks

### DIFF
--- a/casks/zulu-jdk11.rb
+++ b/casks/zulu-jdk11.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk11' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :high_sierra'
   else
     version '11.52.13,11.0.13'
     sha256 'e26e3df726f53f0ac91f35dd07791fc81cf18a1347ab56a7a156de256db60b8c'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 11'

--- a/casks/zulu-jdk12.rb
+++ b/casks/zulu-jdk12.rb
@@ -7,8 +7,6 @@ cask 'zulu-jdk12' do
     name 'Azul Zulu® JDK 12'
     homepage 'https://www.azul.com/downloads/zulu-community/'
 
-    depends_on macos: '>= :high_sierra'
-
     pkg "Double-Click to Install Zulu #{version.major}.pkg"
 
     uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"

--- a/casks/zulu-jdk13.rb
+++ b/casks/zulu-jdk13.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk13' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :high_sierra'
   else
     version '13.44.13,13.0.9'
     sha256 'c93142763d69c59c7ce38964754b08a1755f8318955ea40167bda6e485859566'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 13'

--- a/casks/zulu-jdk14.rb
+++ b/casks/zulu-jdk14.rb
@@ -7,8 +7,6 @@ cask 'zulu-jdk14' do
     name 'Azul Zulu® JDK 14'
     homepage 'https://www.azul.com/downloads/zulu-community/'
 
-    depends_on macos: '>= :high_sierra'
-
     pkg "Double-Click to Install Zulu #{version.major}.pkg"
 
     uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"

--- a/casks/zulu-jdk15.rb
+++ b/casks/zulu-jdk15.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk15' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :high_sierra'
   else
     version '15.36.13,15.0.5'
     sha256 'c255dcf3e1165864846f3d67b7da96dd07230a8def64b4693ad66b12cea0a301'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 15'

--- a/casks/zulu-jdk16.rb
+++ b/casks/zulu-jdk16.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk16' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :high_sierra'
   else
     version '16.32.15,16.0.2'
     sha256 'f6c6ff8d6afdb45040ef8dac4b0c0798f4938bd10e82b0edd54bfd58e8b74032'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 16'

--- a/casks/zulu-jdk17.rb
+++ b/casks/zulu-jdk17.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk17' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :mojave'
   else
     version '17.38.21,17.0.5'
     sha256 '73b0732f78726acca5ad8ceb1e43898d8c7982c4debc24e88b4fcd12d6e8c07a'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.before_comma}-ca-jdk#{version.after_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 17'

--- a/casks/zulu-jdk7.rb
+++ b/casks/zulu-jdk7.rb
@@ -7,8 +7,6 @@ cask 'zulu-jdk7' do
     name 'Azul Zulu® JDK 7'
     homepage 'https://www.azul.com/downloads/zulu-community/'
 
-    depends_on macos: '>= :high_sierra'
-
     pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
     uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"

--- a/casks/zulu-jdk8.rb
+++ b/casks/zulu-jdk8.rb
@@ -6,16 +6,12 @@ cask 'zulu-jdk8' do
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-ca-jdk#{version.before_comma}-macosx_x64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :high_sierra'
   else
     version '8.0.312,8.58.0.13'
     sha256 '15ac8c0f246b0c2065200f8e864faff8bf9340cf7d960a60857af67454b58746'
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-ca-jdk#{version.before_comma}-macosx_aarch64.dmg",
         referer: 'https://www.azul.com/downloads/zulu-community/'
-
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 8'


### PR DESCRIPTION
## Problem

Any `brew` command that evaluates this tap's casks (including installing unrelated formulas like `shopify-cli`) emits deprecation warnings and a hard error:

```
Warning: Calling string comparison format for depends_on macos: is deprecated! Use depends_on macos: :big_sur instead.
Please report this issue to the shopify/homebrew-shopify tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
/opt/homebrew/Library/Taps/shopify/homebrew-shopify/casks/zulu-jdk11.rb:18

Error: Calling depends_on macos: :high_sierra is disabled! There is no replacement.
Please report this issue to the shopify/homebrew-shopify tap (not Homebrew/* repositories):
/opt/homebrew/Library/Taps/shopify/homebrew-shopify/casks/zulu-jdk12.rb:10
```

Two Homebrew changes stack here:
1. The string comparison format (`depends_on macos: '>= :high_sierra'`) is deprecated in favor of the bare symbol form.
2. Symbols for EOL macOS versions (High Sierra, Mojave) have been disabled outright, so migrating to the suggested symbol form is not possible for most of these lines.

## Fix

Remove the `depends_on macos:` lines from the zulu-jdk casks entirely. Every constraint in them (`>= :high_sierra`, `>= :mojave`, `>= :big_sur`) is vacuous on any macOS that current Homebrew supports — and on the Apple Silicon branches, Big Sur was the first ARM macOS anyway. Deletions only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)